### PR TITLE
feat(widgets): ⚡ add parallel execution & resilience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,12 @@ This dual-path system enables automatic error handling and conditional branching
 ### Widget Execution Flow
 
 1. **Entry Point:** `Flow.create(name).start(widget).end()` returns an executable function
-2. **Payload Wrapping:** Input data is automatically wrapped as `{ payload: originalData, variables: {} }`
-3. **Tree Traversal:** Widgets execute depth-first through the `left` path
-4. **Error Handling:** Exceptions automatically route to the `right` path (else branch)
-5. **Immutability:** Original payload is frozen; widgets add new properties or use `variables` object
+2. **Payload Wrapping:** Input data is automatically wrapped as `{ payload: originalData }`
+3. **Lifecycle Hook:** Widgets implement `protected async run(ctx)`; the base `process()` runs it, then advances into `left`, awaiting the whole chain. Legacy widgets that override `process()` and call `await super.process()` still work.
+4. **Error Handling:** A thrown value routes to the widget's `right` path. When no failure path exists, real errors propagate (no silent swallow) while a `RouteSignal` (control flow) completes quietly.
+5. **Immutability:** `variables` entries are read-only; widgets add new payload properties or use the `variables` object
 
-### Five Core Widgets
+### Core Widgets
 
 #### 1. Flow ([src/flow.class.ts](src/flow.class.ts))
 - Entry point and workflow executor
@@ -80,9 +80,36 @@ This dual-path system enables automatic error handling and conditional branching
 
 #### 5. CustomWidget ([src/custom-widget.ts](src/custom-widget.ts))
 - Base class for extending with custom business logic
-- Implement `async process(data: any): Promise<void>` method
-- Use `super.register(message, level)` for logging ('info', 'warn', 'error')
-- Must call `super.process(a)` at the end of custom process method
+- Override `protected async run(data: any): Promise<void>` with the operation (the base advances the chain)
+- Throw to route to the `.elseMoveTo()` failure path
+- Use `this.register(message, level)` for logging ('info', 'warn', 'error')
+- A subclass that adds config methods should re-declare `static create(name)` so the returned type exposes them
+- Legacy contract (override `process()` + call `await super.process()`) still works
+
+#### 6. Parallel ([src/parallel.ts](src/parallel.ts))
+- Fan-out/fan-in: runs named branches concurrently on isolated context clones, then merges
+- `concurrency(n)` caps in-flight branches; `onError('fail-fast' | 'settle')`; `into(path)` or custom `merge(fn)`
+- Usage: `Parallel.create('x').branch('a', wA).branch('b', wB).into('payload.sources')`
+
+#### 7. ParallelMap ([src/parallel-map.ts](src/parallel-map.ts))
+- Concurrency-limited batch map over an array (the ETL batch workhorse)
+- `from('{{ payload.items }}')`, `withConcurrency(n)`, `each(widgetOrFn)`, `into(path)`, `collectErrorsInto(path)`
+- `onItemError('collect' | 'fail-fast')`; `collect` gathers `{ index, item, error }` for partial-failure ETL
+
+#### 8. Retry ([src/retry.ts](src/retry.ts))
+- Decorator that re-runs `wrap(branch)` on retryable failures with fixed/exponential backoff
+- Never retries a `RouteSignal`; exhausted attempts route to `.elseMoveTo()`
+- `attempts(n)`, `backoff(strategy, options)`, `retryIf(fn)`, `isolate()`
+
+#### 9. CircuitBreaker ([src/circuit-breaker.ts](src/circuit-breaker.ts))
+- Decorator with closed/open/half-open state held on the instance (shared across flow runs)
+- Opens after `threshold` consecutive failures; fast-fails to `.elseMoveTo()` until `cooldown` elapses
+- Throws `CircuitOpenError` while open; compose as `CircuitBreaker.wrap(Retry.wrap(op))`
+
+#### Internals
+- `RouteSignal` ([src/route-signal.ts](src/route-signal.ts)): typed control-flow marker (not an `Error`) that distinguishes branch routing from real failures
+- `runWithConcurrency` ([src/concurrency.ts](src/concurrency.ts)): dependency-free ordered async pool used by both parallel widgets
+- `computeBackoff` ([src/backoff.ts](src/backoff.ts)): fixed/exponential backoff with optional jitter
 
 ### Template Expression System
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Extract values from nested objects using template expressions: `{{ payload.user.
 ### 🎨 **Fully Extensible**
 Create custom widgets by extending `CustomWidget`. Implement your business logic while inheriting workflow orchestration.
 
+### ⚡ **Parallel & Resilient**
+Fan out work with `Parallel`, process batches with bounded concurrency via `ParallelMap`, and harden steps with `Retry` and `CircuitBreaker`.
+
 ### 🛡️ **Type-Safe**
 Written in TypeScript with strict mode. Full type inference and IntelliSense support.
 
@@ -220,6 +223,33 @@ const transformFlow = Flow.create('data_transform')
 
 **[See full transformation example →](examples/04-data-transformation.ts)**
 
+### Resilient Parallel ETL
+
+Concurrent extraction, bounded-concurrency transforms with partial-failure handling, and resilient loads:
+
+```typescript
+const etl = Flow.create('resilient_etl')
+  .start(
+    Parallel.create('extract')
+      .branch('warehouse', FetchWarehouse.create('warehouse'))
+      .branch('billing', FetchBilling.create('billing'))
+      .moveTo(
+        ParallelMap.create('transform')
+          .from('{{ payload.records }}')
+          .withConcurrency(10)
+          .each(async (record) => normalize(record))
+          .moveTo(
+            CircuitBreaker.create('breaker').wrap(
+              Retry.create('retry').attempts(3).wrap(LoadWidget.create('load'))
+            )
+          )
+      )
+  )
+  .end();
+```
+
+**[See full resilient ETL example →](examples/05-resilient-parallel-etl.ts)**
+
 ---
 
 ## 📚 Documentation
@@ -294,21 +324,16 @@ Compare.is(value).lesserThan(100)           // <
 
 #### 🎨 CustomWidget
 
-Extend with your own business logic.
+Extend with your own business logic by overriding the `run()` lifecycle hook. Implement your operation; the engine advances the workflow and awaits the rest of the chain for you.
 
 ```typescript
 class SendEmailWidget extends CustomWidget {
-  async process(data: WorkflowData): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const email = data.payload.user?.email;
 
-    // Your business logic
     await sendEmail(email, 'Welcome!');
 
-    // Log activity
     this.register(`Email sent to ${email}`, 'info');
-
-    // IMPORTANT: Call super.process to continue workflow
-    await super.process(data);
   }
 }
 
@@ -317,10 +342,74 @@ const emailWidget = SendEmailWidget.create('send_welcome_email');
 ```
 
 **Custom Widget Requirements:**
-1. Extend `CustomWidget` class
-2. Implement `async process(data): Promise<void>`
-3. Call `await super.process(data)` at the end
+1. Extend `CustomWidget`
+2. Override `protected async run(data): Promise<void>` with your logic
+3. Throw to route execution to the failure path (`elseMoveTo`)
 4. Use `this.register(message, level)` for logging
+
+> The legacy pattern of overriding `process(data)` and calling `await super.process(data)` still works, but `run()` is recommended: it cannot forget to await the downstream chain and keeps your operation separate from traversal. A custom widget that adds its own configuration methods should re-declare `static create(name)` so the returned type exposes them.
+
+#### ⚡ Parallel
+
+Run independent branches concurrently on isolated context clones, then merge.
+
+```typescript
+const extract = Parallel.create('extract_sources')
+  .branch('warehouse', FetchWarehouseWidget.create('warehouse'))
+  .branch('billing', FetchBillingWidget.create('billing'))
+  .concurrency(2)          // optional cap; default runs all at once
+  .onError('settle')       // 'fail-fast' (default) | 'settle'
+  .into('payload.sources') // results keyed by branch name
+  .moveTo(combineWidget);
+```
+
+#### 🧺 ParallelMap
+
+Map an async operation over an array with a concurrency cap and partial-failure handling. The ETL batch workhorse.
+
+```typescript
+const transform = ParallelMap.create('transform_records')
+  .from('{{ payload.records }}')
+  .withConcurrency(10)
+  .each(async (record) => normalize(record))  // a widget branch or an async function
+  .into('payload.processed')                   // ordered successes
+  .collectErrorsInto('payload.failures')       // { index, item, error }[]
+  .moveTo(loadWidget);
+```
+
+#### 🔁 Retry
+
+Re-run a wrapped branch on retryable failures using fixed or exponential backoff. Routing signals (such as a `Split` taking its else path) are never retried.
+
+```typescript
+const resilientLoad = Retry.create('load_with_retry')
+  .attempts(3)
+  .backoff('exponential', { baseMs: 100, factor: 2, maxMs: 5000, jitter: true })
+  .retryIf((error) => error instanceof NetworkError)
+  .wrap(LoadWidget.create('load'))
+  .moveTo(next)
+  .elseMoveTo(loadFailed);  // taken once attempts are exhausted
+```
+
+#### 🔌 CircuitBreaker
+
+Stop hammering a failing dependency. After `threshold` consecutive failures the circuit opens and fast-fails to the failure path until `cooldown` elapses, then a half-open probe decides whether to close. State lives on the instance, so it is shared across every flow invocation.
+
+```typescript
+const breaker = CircuitBreaker.create('billing_breaker')
+  .threshold(5)
+  .cooldown(30000)
+  .wrap(CallBillingApi.create('billing'))
+  .moveTo(next)
+  .elseMoveTo(serveFromCache);  // fallback while the circuit is open
+```
+
+Compose the two: place `CircuitBreaker` outside `Retry` so the breaker judges the post-retry outcome.
+
+```typescript
+CircuitBreaker.create('breaker')
+  .wrap(Retry.create('retry').attempts(3).wrap(LoadWidget.create('load')));
+```
 
 ---
 
@@ -377,6 +466,57 @@ const emailWidget = SendEmailWidget.create('send_welcome_email');
 | `register(msg, level)` | `msg: any, level: string` | `void` | Log messages |
 | `moveTo(widget)` | `widget: Widget` | `CustomWidget` | Set success path |
 | `elseMoveTo(widget)` | `widget: Widget` | `CustomWidget` | Set failure path |
+
+### Parallel
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `create(name)` | `name: string` | `Parallel` | Static factory method |
+| `branch(name, widget)` | `name: string, widget: Widget` | `Parallel` | Register a concurrent branch |
+| `concurrency(limit)` | `limit: number` | `Parallel` | Cap in-flight branches (0 = all) |
+| `onError(mode)` | `'fail-fast' \| 'settle'` | `Parallel` | Group failure behavior |
+| `into(path)` | `path: string` | `Parallel` | Payload key for merged results |
+| `merge(fn)` | `(ctx, results) => void` | `Parallel` | Custom merge reducer |
+| `clone(fn)` | `(ctx) => ctx` | `Parallel` | Custom per-branch cloner |
+| `moveTo(widget)` / `elseMoveTo(widget)` | `widget: Widget` | `Parallel` | Success / failure path |
+
+### ParallelMap
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `create(name)` | `name: string` | `ParallelMap` | Static factory method |
+| `from(path)` | `path: string` | `ParallelMap` | Template expression for the source array |
+| `as(key)` | `key: string` | `ParallelMap` | Payload key for the injected item (default `item`) |
+| `withConcurrency(limit)` | `limit: number` | `ParallelMap` | In-flight cap (default `5`) |
+| `each(task)` | `Widget \| (item, ctx) => result` | `ParallelMap` | Per-item operation |
+| `into(path)` | `path: string` | `ParallelMap` | Payload key for ordered successes |
+| `onItemError(mode)` | `'collect' \| 'fail-fast'` | `ParallelMap` | Per-item failure behavior |
+| `collectErrorsInto(path)` | `path: string` | `ParallelMap` | Payload key for collected failures |
+| `moveTo(widget)` / `elseMoveTo(widget)` | `widget: Widget` | `ParallelMap` | Success / failure path |
+
+### Retry
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `create(name)` | `name: string` | `Retry` | Static factory method |
+| `attempts(count)` | `count: number` | `Retry` | Max attempts (default `3`) |
+| `backoff(strategy, options)` | `'fixed' \| 'exponential', BackoffOptions` | `Retry` | Backoff configuration |
+| `retryIf(predicate)` | `(error) => boolean` | `Retry` | Which errors are retryable |
+| `isolate()` | - | `Retry` | Run each attempt on a fresh clone |
+| `wrap(widget)` | `widget: Widget` | `Retry` | Branch to retry |
+| `moveTo(widget)` / `elseMoveTo(widget)` | `widget: Widget` | `Retry` | Success / exhausted path |
+
+### CircuitBreaker
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `create(name)` | `name: string` | `CircuitBreaker` | Static factory method |
+| `threshold(count)` | `count: number` | `CircuitBreaker` | Failures that open the circuit (default `5`) |
+| `cooldown(ms)` | `ms: number` | `CircuitBreaker` | Open duration before half-open (default `30000`) |
+| `halfOpenAttempts(count)` | `count: number` | `CircuitBreaker` | Concurrent probes while half-open (default `1`) |
+| `isFailure(predicate)` | `(error) => boolean` | `CircuitBreaker` | Which errors count as failures |
+| `wrap(widget)` | `widget: Widget` | `CircuitBreaker` | Protected branch |
+| `moveTo(widget)` / `elseMoveTo(widget)` | `widget: Widget` | `CircuitBreaker` | Success / open-or-failure path |
 
 ---
 
@@ -548,8 +688,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📊 Roadmap
 
-- [ ] Parallel execution support
-- [ ] Built-in retry and circuit breaker patterns
+- [x] Parallel execution support
+- [x] Built-in retry and circuit breaker patterns
 - [ ] Visual workflow builder/debugger
 - [ ] Performance monitoring and metrics
 - [ ] Plugin system for common integrations

--- a/examples/01-etl-pipeline.ts
+++ b/examples/01-etl-pipeline.ts
@@ -1,45 +1,42 @@
 /**
  * ETL Pipeline Example
  *
- * This example demonstrates how to build an ETL (Extract, Transform, Load) pipeline
- * for processing user data from an API, validating it, transforming it, and then
- * routing it to different destinations based on business rules.
+ * Demonstrates a classic Extract, Transform, Load pipeline: data is fetched from
+ * an API, validated, transformed, and routed to different destinations based on
+ * business rules.
+ *
+ * Custom widgets here use the `run()` lifecycle hook: implement the operation
+ * and let the engine advance the workflow. Awaited delays simulate real I/O, and
+ * because the engine awaits the whole chain, the resolved result reflects every
+ * stage having completed.
  *
  * Use Case: Customer data synchronization between systems
  */
 
 import { Flow, SetVariable, Split, Compare, CustomWidget } from '../src';
 
-// Custom widget to fetch data from API
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 class FetchCustomersWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
-    try {
-      // Simulate API call
-      const customers = [
-        { id: 1, name: 'John Doe', email: 'john@example.com', age: 30, country: 'USA', status: 'active' },
-        { id: 2, name: 'Jane Smith', email: 'jane@example.com', age: 25, country: 'UK', status: 'active' },
-        { id: 3, name: 'Bob Johnson', email: 'bob@example.com', age: 45, country: 'USA', status: 'inactive' },
-      ];
+  protected async run(data: any): Promise<void> {
+    await delay(30);
 
-      // Add fetched data to payload
-      data.payload.customers = customers;
+    data.payload.customers = [
+      { id: 1, name: 'John Doe', email: 'John@Example.com', age: 30, country: 'USA', status: 'active' },
+      { id: 2, name: 'Jane Smith', email: 'Jane@Example.com', age: 25, country: 'UK', status: 'active' },
+      { id: 3, name: 'Bob Johnson', email: 'Bob@Example.com', age: 45, country: 'USA', status: 'inactive' },
+    ];
 
-      this.register('Fetched customers from API', 'info');
-      await super.process(data);
-    } catch (error) {
-      this.register(`Error fetching customers: ${error}`, 'error');
-      throw error;
-    }
+    this.register('Fetched customers from API', 'info');
   }
 }
 
-// Custom widget to transform customer data
 class TransformCustomersWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
-    const customers = data.payload.customers || [];
+  protected async run(data: any): Promise<void> {
+    const customers = data.payload.customers ?? [];
 
-    // Transform data: add full name, normalize email
-    const transformedCustomers = customers.map((customer: any) => ({
+    data.payload.transformedCustomers = customers.map((customer: any) => ({
       ...customer,
       fullName: customer.name,
       email: customer.email.toLowerCase(),
@@ -47,104 +44,87 @@ class TransformCustomersWidget extends CustomWidget {
       processedAt: new Date().toISOString(),
     }));
 
-    data.payload.transformedCustomers = transformedCustomers;
-    this.register(`Transformed ${transformedCustomers.length} customers`, 'info');
-    await super.process(data);
+    this.register(
+      `Transformed ${data.payload.transformedCustomers.length} customers`,
+      'info'
+    );
   }
 }
 
-// Custom widget to load data to destination
 class LoadToDestinationWidget extends CustomWidget {
-  private destination: string = '';
+  private destination = '';
+
+  static create(name: string) {
+    return new this(Symbol(name));
+  }
 
   setDestination(destination: string) {
     this.destination = destination;
+
     return this;
   }
 
-  async process(data: any): Promise<void> {
-    const customers = data.payload.transformedCustomers || [];
+  protected async run(data: any): Promise<void> {
+    await delay(20);
 
-    // Simulate loading to destination (database, API, file, etc.)
+    const customers = data.payload.transformedCustomers ?? [];
     this.register(
       `Loading ${customers.length} customers to ${this.destination}`,
       'info'
     );
 
-    // Here you would implement actual loading logic
     data.payload.loadedTo = this.destination;
     data.payload.loadedCount = customers.length;
-
-    await super.process(data);
   }
 }
 
-// Build the ETL pipeline
+class NoCustomersWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    this.register('No customers to process', 'warn');
+    data.payload.result = 'NO_CUSTOMERS';
+  }
+}
+
 const buildETLPipeline = () => {
-  // Step 1: Fetch data
   const fetchWidget = FetchCustomersWidget.create('fetch_customers');
 
-  // Step 2: Extract total count
-  const extractCount = SetVariable
-    .create('extract_customer_count')
-    .variable('totalCustomers', '{{ payload.customers.length }}');
+  const extractCount = SetVariable.create('extract_customer_count').variable(
+    'totalCustomers',
+    '{{ payload.customers.length }}'
+  );
 
-  // Step 3: Transform data
   const transformWidget = TransformCustomersWidget.create('transform_customers');
 
-  // Step 4: Check if we have customers to process
-  const checkCustomersExist = Split
-    .create('check_customers_exist')
-    .case((data: any) => Compare
-      .is(data.variables.totalCustomers)
-      .greaterThan(0)
-    );
+  const checkCustomersExist = Split.create('check_customers_exist').case(
+    (data: any) => Compare.is(data.variables.totalCustomers).greaterThan(0)
+  );
 
-  // Step 5a: If customers exist, route based on country
-  const routeByCountry = Split
-    .create('route_by_country')
-    .case((data: any) => {
-      const customers = data.payload.transformedCustomers || [];
-      const usaCustomers = customers.filter((c: any) => c.country === 'USA');
-      return usaCustomers.length > 0;
-    });
+  const routeByCountry = Split.create('route_by_country').case((data: any) => {
+    const customers = data.payload.transformedCustomers ?? [];
+    return customers.some((customer: any) => customer.country === 'USA');
+  });
 
-  // Load to USA database
-  const loadToUSA = LoadToDestinationWidget.create('load_to_usa').setDestination('USA_DATABASE');
+  const loadToUSA = LoadToDestinationWidget.create('load_to_usa').setDestination(
+    'USA_DATABASE'
+  );
 
-  // Load to International database
-  const loadToInternational = LoadToDestinationWidget.create('load_to_intl').setDestination('INTL_DATABASE');
+  const loadToInternational = LoadToDestinationWidget.create(
+    'load_to_intl'
+  ).setDestination('INTL_DATABASE');
 
-  // Step 5b: If no customers, log warning
-  class NoCustomersWidget extends CustomWidget {
-    async process(data: any): Promise<void> {
-      this.register('No customers to process', 'warn');
-      data.payload.result = 'NO_CUSTOMERS';
-      await super.process(data);
-    }
-  }
   const noCustomersWidget = NoCustomersWidget.create('no_customers_handler');
 
-  // Connect the pipeline
   fetchWidget.moveTo(extractCount);
   extractCount.moveTo(transformWidget);
   transformWidget.moveTo(checkCustomersExist);
 
-  checkCustomersExist
-    .moveTo(routeByCountry)
-    .elseMoveTo(noCustomersWidget);
+  checkCustomersExist.moveTo(routeByCountry).elseMoveTo(noCustomersWidget);
 
-  routeByCountry
-    .moveTo(loadToUSA)
-    .elseMoveTo(loadToInternational);
+  routeByCountry.moveTo(loadToUSA).elseMoveTo(loadToInternational);
 
-  // Create and return the flow
-  return Flow.create('etl_customer_pipeline')
-    .start(fetchWidget)
-    .end();
+  return Flow.create('etl_customer_pipeline').start(fetchWidget).end();
 };
 
-// Execute the pipeline
 const runExample = async () => {
   console.log('=== ETL Pipeline Example ===\n');
 
@@ -162,7 +142,6 @@ const runExample = async () => {
   console.log(JSON.stringify(result.variables, null, 2));
 };
 
-// Run if executed directly
 if (require.main === module) {
   runExample().catch(console.error);
 }

--- a/examples/03-order-processing-workflow.ts
+++ b/examples/03-order-processing-workflow.ts
@@ -13,9 +13,8 @@
 
 import { Flow, SetVariable, Split, Compare, CustomWidget } from '../src';
 
-// Custom widget to validate order
 class ValidateOrderWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const order = data.payload.order;
 
     if (!order || !order.items || order.items.length === 0) {
@@ -35,17 +34,15 @@ class ValidateOrderWidget extends CustomWidget {
   }
 }
 
-// Custom widget to check inventory
 class CheckInventoryWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const items = data.payload.order.items;
 
-    // Simulate inventory check
     const inventory: Record<string, number> = {
-      'PROD001': 100,
-      'PROD002': 50,
-      'PROD003': 0, // Out of stock
-      'PROD004': 25,
+      PROD001: 100,
+      PROD002: 50,
+      PROD003: 0,
+      PROD004: 25,
     };
 
     const itemsInStock = items.every((item: any) => {
@@ -63,34 +60,34 @@ class CheckInventoryWidget extends CustomWidget {
   }
 }
 
-// Custom widget to calculate order total
 class CalculateOrderTotalWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const items = data.payload.order.items;
 
     const subtotal = items.reduce((sum: number, item: any) => {
-      return sum + (item.price * item.quantity);
+      return sum + item.price * item.quantity;
     }, 0);
 
     data.payload.orderSubtotal = subtotal;
-    data.payload.orderItemCount = items.reduce((sum: number, item: any) => sum + item.quantity, 0);
+    data.payload.orderItemCount = items.reduce(
+      (sum: number, item: any) => sum + item.quantity,
+      0
+    );
 
     this.register(`Order subtotal calculated: $${subtotal.toFixed(2)}`, 'info');
   }
 }
 
-// Custom widget to apply discount based on customer tier
 class ApplyDiscountWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const customerTier = data.payload.order.customerTier || 'BRONZE';
     const subtotal = data.payload.orderSubtotal || 0;
 
-    // Discount rates by tier
     const discountRates: Record<string, number> = {
-      'BRONZE': 0,
-      'SILVER': 0.05,
-      'GOLD': 0.10,
-      'PLATINUM': 0.15,
+      BRONZE: 0,
+      SILVER: 0.05,
+      GOLD: 0.1,
+      PLATINUM: 0.15,
     };
 
     const discountRate = discountRates[customerTier] || 0;
@@ -108,18 +105,16 @@ class ApplyDiscountWidget extends CustomWidget {
   }
 }
 
-// Custom widget to calculate shipping
 class CalculateShippingWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const shippingCountry = data.payload.order.shippingAddress?.country || 'USA';
     const itemCount = data.payload.orderItemCount || 0;
 
-    // Shipping rates
     const baseRates: Record<string, number> = {
-      'USA': 5.99,
-      'CANADA': 9.99,
-      'UK': 12.99,
-      'INTERNATIONAL': 19.99,
+      USA: 5.99,
+      CANADA: 9.99,
+      UK: 12.99,
+      INTERNATIONAL: 19.99,
     };
 
     const baseRate = baseRates[shippingCountry] || baseRates['INTERNATIONAL'];
@@ -127,33 +122,39 @@ class CalculateShippingWidget extends CustomWidget {
     const shippingCost = baseRate + additionalItemFee;
 
     data.payload.shippingCost = shippingCost;
-    data.payload.orderTotal = (data.payload.totalAfterDiscount || 0) + shippingCost;
+    data.payload.orderTotal =
+      (data.payload.totalAfterDiscount || 0) + shippingCost;
 
     this.register(`Shipping cost calculated: $${shippingCost.toFixed(2)}`, 'info');
   }
 }
 
-// Custom widget to route to fulfillment center
 class RouteToFulfillmentWidget extends CustomWidget {
-  private center: string;
+  private center = '';
 
-  constructor(name: string, center: string) {
-    super(name);
-    this.center = center;
+  static create(name: string) {
+    return new this(Symbol(name));
   }
 
-  async process(data: any): Promise<void> {
+  setCenter(center: string) {
+    this.center = center;
+
+    return this;
+  }
+
+  protected async run(data: any): Promise<void> {
     data.payload.fulfillmentCenter = this.center;
     data.payload.orderStatus = 'PROCESSING';
-    data.payload.estimatedShipDate = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
+    data.payload.estimatedShipDate = new Date(
+      Date.now() + 2 * 24 * 60 * 60 * 1000
+    ).toISOString();
 
     this.register(`Order routed to ${this.center} fulfillment center`, 'info');
   }
 }
 
-// Custom widget to handle out of stock
 class OutOfStockWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     data.payload.orderStatus = 'ON_HOLD';
     data.payload.reason = 'ITEMS_OUT_OF_STOCK';
 
@@ -161,13 +162,11 @@ class OutOfStockWidget extends CustomWidget {
   }
 }
 
-// Custom widget to send confirmation
 class SendConfirmationWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const order = data.payload.order;
     const total = data.payload.orderTotal;
 
-    // Simulate sending email
     this.register(
       `Confirmation email sent to customer ${order.customerId} for order total $${total?.toFixed(2)}`,
       'info'
@@ -177,106 +176,79 @@ class SendConfirmationWidget extends CustomWidget {
   }
 }
 
-// Build the order processing workflow
+class ApplyFreeShippingWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.shippingCost = 0;
+    data.payload.orderTotal = data.payload.totalAfterDiscount;
+    this.register('Free shipping applied (order over $100)', 'info');
+  }
+}
+
 const buildOrderProcessingWorkflow = () => {
-  // Step 1: Extract order data
-  const extractOrderData = SetVariable
-    .create('extract_order_data')
+  const extractOrderData = SetVariable.create('extract_order_data')
     .variable('customerId', '{{ payload.order.customerId }}')
     .variable('orderCountry', '{{ payload.order.shippingAddress.country }}');
 
-  // Step 2: Validate order
-  const validateOrder = new ValidateOrderWidget('validate_order');
+  const validateOrder = ValidateOrderWidget.create('validate_order');
 
-  // Step 3: Check inventory
-  const checkInventory = new CheckInventoryWidget('check_inventory');
+  const checkInventory = CheckInventoryWidget.create('check_inventory');
 
-  // Step 4: Split based on inventory availability
-  const checkInventoryAvailable = Split
-    .create('check_inventory_available')
-    .case((data: any) => Compare
-      .is(data.payload.allItemsInStock)
-      .equal(true)
-    );
+  const checkInventoryAvailable = Split.create(
+    'check_inventory_available'
+  ).case((data: any) => Compare.is(data.payload.allItemsInStock).equal(true));
 
-  // If out of stock, put on hold
-  const outOfStock = new OutOfStockWidget('out_of_stock_handler');
+  const outOfStock = OutOfStockWidget.create('out_of_stock_handler');
 
-  // Step 5: Calculate order total
-  const calculateTotal = new CalculateOrderTotalWidget('calculate_order_total');
+  const calculateTotal = CalculateOrderTotalWidget.create(
+    'calculate_order_total'
+  );
 
-  // Step 6: Apply discount
-  const applyDiscount = new ApplyDiscountWidget('apply_discount');
+  const applyDiscount = ApplyDiscountWidget.create('apply_discount');
 
-  // Step 7: Check if order qualifies for free shipping
-  const checkFreeShipping = Split
-    .create('check_free_shipping')
-    .case((data: any) => Compare
-      .is(data.payload.totalAfterDiscount)
-      .greaterThan(99.99)
-    );
+  const checkFreeShipping = Split.create('check_free_shipping').case(
+    (data: any) => Compare.is(data.payload.totalAfterDiscount).greaterThan(99.99)
+  );
 
-  // Free shipping handler
-  const applyFreeShipping = new (class extends CustomWidget {
-    async process(data: any): Promise<void> {
-      data.payload.shippingCost = 0;
-      data.payload.orderTotal = data.payload.totalAfterDiscount;
-      this.register('Free shipping applied (order over $100)', 'info');
-    }
-  })('apply_free_shipping');
+  const applyFreeShipping = ApplyFreeShippingWidget.create('apply_free_shipping');
 
-  // Calculate regular shipping
-  const calculateShipping = new CalculateShippingWidget('calculate_shipping');
+  const calculateShipping = CalculateShippingWidget.create('calculate_shipping');
 
-  // Step 8: Route to fulfillment center based on country
-  const routeByCountry = Split
-    .create('route_by_country')
-    .case((data: any) => {
-      const country = data.payload.order.shippingAddress?.country || '';
-      return Compare.is(country).in(['USA', 'CANADA']);
-    });
+  const routeByCountry = Split.create('route_by_country').case((data: any) => {
+    const country = data.payload.order.shippingAddress?.country || '';
+    return Compare.is(country).in(['USA', 'CANADA']);
+  });
 
-  const routeToNorthAmerica = new RouteToFulfillmentWidget('route_to_na', 'NORTH_AMERICA_FC');
-  const routeToInternational = new RouteToFulfillmentWidget('route_to_intl', 'INTERNATIONAL_FC');
+  const routeToNorthAmerica = RouteToFulfillmentWidget.create(
+    'route_to_na'
+  ).setCenter('NORTH_AMERICA_FC');
+  const routeToInternational = RouteToFulfillmentWidget.create(
+    'route_to_intl'
+  ).setCenter('INTERNATIONAL_FC');
 
-  // Step 9: Send confirmation
-  const sendConfirmation = new SendConfirmationWidget('send_confirmation');
+  const sendConfirmation = SendConfirmationWidget.create('send_confirmation');
 
-  // Build the workflow chain
   extractOrderData.moveTo(validateOrder);
   validateOrder.moveTo(checkInventory);
   checkInventory.moveTo(checkInventoryAvailable);
 
-  checkInventoryAvailable
-    .moveTo(calculateTotal)
-    .elseMoveTo(outOfStock);
+  checkInventoryAvailable.moveTo(calculateTotal).elseMoveTo(outOfStock);
 
   calculateTotal.moveTo(applyDiscount);
   applyDiscount.moveTo(checkFreeShipping);
 
-  checkFreeShipping
-    .moveTo(applyFreeShipping)
-    .elseMoveTo(calculateShipping);
+  checkFreeShipping.moveTo(applyFreeShipping).elseMoveTo(calculateShipping);
 
-  // Both free shipping and regular shipping go to routing
   applyFreeShipping.moveTo(routeByCountry);
   calculateShipping.moveTo(routeByCountry);
 
-  routeByCountry
-    .moveTo(routeToNorthAmerica)
-    .elseMoveTo(routeToInternational);
+  routeByCountry.moveTo(routeToNorthAmerica).elseMoveTo(routeToInternational);
 
-  // Both fulfillment centers send confirmation
   routeToNorthAmerica.moveTo(sendConfirmation);
   routeToInternational.moveTo(sendConfirmation);
 
-  // Create and return the flow
-  return Flow.create('order_processing_workflow')
-    .start(extractOrderData)
-    .end();
+  return Flow.create('order_processing_workflow').start(extractOrderData).end();
 };
 
-// Example: High-value PLATINUM customer order
 const runPlatinumOrderExample = async () => {
   console.log('=== PLATINUM Customer Order (Free Shipping) ===\n');
 
@@ -303,7 +275,6 @@ const runPlatinumOrderExample = async () => {
   console.log(JSON.stringify(result, null, 2));
 };
 
-// Example: International BRONZE customer order
 const runInternationalOrderExample = async () => {
   console.log('\n=== International BRONZE Customer Order ===\n');
 
@@ -328,7 +299,6 @@ const runInternationalOrderExample = async () => {
   console.log(JSON.stringify(result, null, 2));
 };
 
-// Example: Out of stock order
 const runOutOfStockExample = async () => {
   console.log('\n=== Out of Stock Order ===\n');
 
@@ -340,7 +310,7 @@ const runOutOfStockExample = async () => {
       customerId: 'CUST-123',
       customerTier: 'GOLD',
       items: [
-        { productId: 'PROD003', name: 'Monitor', price: 299.99, quantity: 1 }, // Out of stock
+        { productId: 'PROD003', name: 'Monitor', price: 299.99, quantity: 1 },
       ],
       shippingAddress: {
         country: 'CANADA',
@@ -353,16 +323,19 @@ const runOutOfStockExample = async () => {
   console.log(JSON.stringify(result, null, 2));
 };
 
-// Run all examples
 const runAllExamples = async () => {
   await runPlatinumOrderExample();
   await runInternationalOrderExample();
   await runOutOfStockExample();
 };
 
-// Run if executed directly
 if (require.main === module) {
   runAllExamples().catch(console.error);
 }
 
-export { buildOrderProcessingWorkflow, runPlatinumOrderExample, runInternationalOrderExample, runOutOfStockExample };
+export {
+  buildOrderProcessingWorkflow,
+  runPlatinumOrderExample,
+  runInternationalOrderExample,
+  runOutOfStockExample,
+};

--- a/examples/04-data-transformation.ts
+++ b/examples/04-data-transformation.ts
@@ -10,19 +10,20 @@
 
 import { Flow, SetVariable, Split, Compare, CustomWidget } from '../src';
 
-// Custom widget to enrich data
 class EnrichDataWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const userId = data.variables.userId;
 
-    // Simulate enrichment from external API
     const enrichmentData: Record<string, any> = {
       '101': { preferences: { theme: 'dark', language: 'en' }, loyalty: 'gold' },
       '102': { preferences: { theme: 'light', language: 'es' }, loyalty: 'silver' },
       '103': { preferences: { theme: 'dark', language: 'fr' }, loyalty: 'bronze' },
     };
 
-    const enrichment = enrichmentData[userId] || { preferences: {}, loyalty: 'none' };
+    const enrichment = enrichmentData[userId] || {
+      preferences: {},
+      loyalty: 'none',
+    };
 
     data.payload.enrichment = enrichment;
 
@@ -30,9 +31,8 @@ class EnrichDataWidget extends CustomWidget {
   }
 }
 
-// Custom widget to normalize data structure
 class NormalizeDataWidget extends CustomWidget {
-  async process(data: any): Promise<void> {
+  protected async run(data: any): Promise<void> {
     const normalized = {
       user: {
         id: data.variables.userId,
@@ -65,16 +65,20 @@ class NormalizeDataWidget extends CustomWidget {
   }
 }
 
-// Custom widget to format output
 class FormatOutputWidget extends CustomWidget {
-  private format: string;
+  private format = 'MINIMAL';
 
-  constructor(name: string, format: string) {
-    super(name);
-    this.format = format;
+  static create(name: string) {
+    return new this(Symbol(name));
   }
 
-  async process(data: any): Promise<void> {
+  setFormat(format: string) {
+    this.format = format;
+
+    return this;
+  }
+
+  protected async run(data: any): Promise<void> {
     const normalized = data.payload.normalized;
 
     if (this.format === 'SUMMARY') {
@@ -98,92 +102,76 @@ class FormatOutputWidget extends CustomWidget {
   }
 }
 
-// Build a complex data transformation workflow
+class ComputeFieldsWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    const fullName = `${data.variables.firstName} ${data.variables.lastName}`;
+    Object.defineProperty(data.variables, 'fullName', {
+      value: fullName,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+
+    const fullAddress = `${data.variables.street}, ${data.variables.city}, ${data.variables.country}`;
+    Object.defineProperty(data.variables, 'fullAddress', {
+      value: fullAddress,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+
+    this.register('Computed fields created', 'info');
+  }
+}
+
 const buildDataTransformationWorkflow = () => {
-  // Step 1: Extract basic user information
-  const extractBasicInfo = SetVariable
-    .create('extract_basic_info')
+  const extractBasicInfo = SetVariable.create('extract_basic_info')
     .variable('userId', '{{ payload.data.user.id }}')
     .variable('firstName', '{{ payload.data.user.profile.name.first }}')
     .variable('lastName', '{{ payload.data.user.profile.name.last }}');
 
-  // Step 2: Extract contact information
-  const extractContactInfo = SetVariable
-    .create('extract_contact_info')
+  const extractContactInfo = SetVariable.create('extract_contact_info')
     .variable('userEmail', '{{ payload.data.user.contact.email }}')
     .variable('userPhone', '{{ payload.data.user.contact.phone }}');
 
-  // Step 3: Extract address information
-  const extractAddressInfo = SetVariable
-    .create('extract_address_info')
+  const extractAddressInfo = SetVariable.create('extract_address_info')
     .variable('street', '{{ payload.data.user.address.street }}')
     .variable('city', '{{ payload.data.user.address.city }}')
     .variable('country', '{{ payload.data.user.address.country }}');
 
-  // Step 4: Extract metadata
-  const extractMetadata = SetVariable
-    .create('extract_metadata')
+  const extractMetadata = SetVariable.create('extract_metadata')
     .variable('accountAge', '{{ payload.data.metadata.accountAge }}')
     .variable('isPremium', '{{ payload.data.metadata.premium }}')
     .variable('totalPurchases', '{{ payload.data.metadata.purchases.total }}');
 
-  // Step 5: Create computed variables (full name and full address)
-  const createComputedFields = new (class extends CustomWidget {
-    async process(data: any): Promise<void> {
-      // Create full name
-      const fullName = `${data.variables.firstName} ${data.variables.lastName}`;
-      Object.defineProperty(data.variables, 'fullName', {
-        value: fullName,
-        writable: false,
-        enumerable: true,
-        configurable: false,
-      });
+  const createComputedFields = ComputeFieldsWidget.create(
+    'create_computed_fields'
+  );
 
-      // Create full address
-      const fullAddress = `${data.variables.street}, ${data.variables.city}, ${data.variables.country}`;
-      Object.defineProperty(data.variables, 'fullAddress', {
-        value: fullAddress,
-        writable: false,
-        enumerable: true,
-        configurable: false,
-      });
+  const enrichData = EnrichDataWidget.create('enrich_data');
 
-      this.register('Computed fields created', 'info');
-    }
-  })('create_computed_fields');
+  const normalizeData = NormalizeDataWidget.create('normalize_data');
 
-  // Step 6: Enrich with external data
-  const enrichData = new EnrichDataWidget('enrich_data');
+  const checkPremiumStatus = Split.create('check_premium_status').case(
+    (data: any) => Compare.is(data.variables.isPremium).equal(true)
+  );
 
-  // Step 7: Normalize the data structure
-  const normalizeData = new NormalizeDataWidget('normalize_data');
+  const formatPremiumOutput = FormatOutputWidget.create(
+    'format_premium_output'
+  ).setFormat('FULL');
 
-  // Step 8: Check if user is premium for output formatting
-  const checkPremiumStatus = Split
-    .create('check_premium_status')
-    .case((data: any) => Compare
-      .is(data.variables.isPremium)
-      .equal(true)
-    );
+  const checkPurchaseCount = Split.create('check_purchase_count').case(
+    (data: any) => Compare.is(data.variables.totalPurchases).greaterThan(10)
+  );
 
-  // Premium users get full format
-  const formatPremiumOutput = new FormatOutputWidget('format_premium_output', 'FULL');
+  const formatSummaryOutput = FormatOutputWidget.create(
+    'format_summary_output'
+  ).setFormat('SUMMARY');
 
-  // Step 9: For non-premium, check purchase count
-  const checkPurchaseCount = Split
-    .create('check_purchase_count')
-    .case((data: any) => Compare
-      .is(data.variables.totalPurchases)
-      .greaterThan(10)
-    );
+  const formatMinimalOutput = FormatOutputWidget.create(
+    'format_minimal_output'
+  ).setFormat('MINIMAL');
 
-  // Active users get summary
-  const formatSummaryOutput = new FormatOutputWidget('format_summary_output', 'SUMMARY');
-
-  // New users get minimal format
-  const formatMinimalOutput = new FormatOutputWidget('format_minimal_output', 'MINIMAL');
-
-  // Build the workflow chain
   extractBasicInfo.moveTo(extractContactInfo);
   extractContactInfo.moveTo(extractAddressInfo);
   extractAddressInfo.moveTo(extractMetadata);
@@ -192,21 +180,17 @@ const buildDataTransformationWorkflow = () => {
   enrichData.moveTo(normalizeData);
   normalizeData.moveTo(checkPremiumStatus);
 
-  checkPremiumStatus
-    .moveTo(formatPremiumOutput)
-    .elseMoveTo(checkPurchaseCount);
+  checkPremiumStatus.moveTo(formatPremiumOutput).elseMoveTo(checkPurchaseCount);
 
   checkPurchaseCount
     .moveTo(formatSummaryOutput)
     .elseMoveTo(formatMinimalOutput);
 
-  // Create and return the flow
   return Flow.create('data_transformation_workflow')
     .start(extractBasicInfo)
     .end();
 };
 
-// Example: Premium user data
 const runPremiumUserExample = async () => {
   console.log('=== Premium User Transformation ===\n');
 
@@ -249,7 +233,6 @@ const runPremiumUserExample = async () => {
   console.log(JSON.stringify(result.variables, null, 2));
 };
 
-// Example: Active non-premium user
 const runActiveUserExample = async () => {
   console.log('\n=== Active Non-Premium User Transformation ===\n');
 
@@ -290,7 +273,6 @@ const runActiveUserExample = async () => {
   console.log(JSON.stringify(result.payload.output, null, 2));
 };
 
-// Example: New user with minimal data
 const runNewUserExample = async () => {
   console.log('\n=== New User Transformation ===\n');
 
@@ -331,16 +313,19 @@ const runNewUserExample = async () => {
   console.log(JSON.stringify(result.payload.output, null, 2));
 };
 
-// Run all examples
 const runAllExamples = async () => {
   await runPremiumUserExample();
   await runActiveUserExample();
   await runNewUserExample();
 };
 
-// Run if executed directly
 if (require.main === module) {
   runAllExamples().catch(console.error);
 }
 
-export { buildDataTransformationWorkflow, runPremiumUserExample, runActiveUserExample, runNewUserExample };
+export {
+  buildDataTransformationWorkflow,
+  runPremiumUserExample,
+  runActiveUserExample,
+  runNewUserExample,
+};

--- a/examples/05-resilient-parallel-etl.ts
+++ b/examples/05-resilient-parallel-etl.ts
@@ -1,0 +1,204 @@
+/**
+ * Resilient Parallel ETL Example
+ *
+ * Showcases the parallel-execution and resilience widgets working together on a
+ * realistic ETL pipeline:
+ *
+ * 1. Extract: fetch orders from two systems concurrently with `Parallel`.
+ * 2. Combine: merge the per-source results into a single records array.
+ * 3. Transform: normalize records with `ParallelMap`, capping concurrency and
+ *    collecting per-item failures instead of aborting the whole batch.
+ * 4. Load: persist the result behind `CircuitBreaker` wrapping `Retry`, so a
+ *    transient outage is retried and a sustained outage fast-fails to a fallback.
+ *
+ * Custom widgets here use the `run()` lifecycle hook: implement the operation
+ * and let the engine advance the workflow (no manual `super.process` call).
+ */
+
+import {
+  CircuitBreaker,
+  CustomWidget,
+  Flow,
+  Parallel,
+  ParallelMap,
+  Retry,
+} from '../src';
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+class FetchWarehouseWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    await delay(40);
+    data.payload.warehouseOrders = [
+      { id: 'W-1', customer: 'acme', amount: 120 },
+      { id: 'W-2', customer: 'globex', amount: 80 },
+    ];
+    this.register('Fetched warehouse orders', 'info');
+  }
+}
+
+class FetchBillingWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    await delay(60);
+    data.payload.billingOrders = [
+      { id: 'B-1', customer: 'initech', amount: 200 },
+      { id: 'B-2', customer: 'umbrella', amount: null },
+    ];
+    this.register('Fetched billing orders', 'info');
+  }
+}
+
+class CombineSourcesWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    const warehouse = data.payload.sources.warehouse.warehouseOrders ?? [];
+    const billing = data.payload.sources.billing.billingOrders ?? [];
+    data.payload.records = [...warehouse, ...billing];
+    this.register(`Combined ${data.payload.records.length} records`, 'info');
+  }
+}
+
+let warehouseLoadAttempts = 0;
+
+class LoadWarehouseWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    warehouseLoadAttempts++;
+    await delay(20);
+
+    if (warehouseLoadAttempts < 3) {
+      this.register(
+        `Load attempt ${warehouseLoadAttempts} failed (transient)`,
+        'warn'
+      );
+      throw new Error('warehouse temporarily unavailable');
+    }
+
+    data.payload.loadResult = {
+      destination: 'DATA_WAREHOUSE',
+      loadedCount: data.payload.processed.length,
+    };
+    this.register(`Loaded ${data.payload.processed.length} records`, 'info');
+  }
+}
+
+const buildResilientPipeline = () => {
+  const extract = Parallel.create('extract_sources')
+    .branch('warehouse', FetchWarehouseWidget.create('fetch_warehouse'))
+    .branch('billing', FetchBillingWidget.create('fetch_billing'))
+    .into('payload.sources');
+
+  const combine = CombineSourcesWidget.create('combine_sources');
+
+  const normalize = ParallelMap.create('normalize_records')
+    .from('{{ payload.records }}')
+    .withConcurrency(3)
+    .each(async (order: any) => {
+      await delay(10);
+
+      if (typeof order.amount !== 'number') {
+        throw new Error(`order ${order.id} has an invalid amount`);
+      }
+
+      return {
+        ...order,
+        customer: order.customer.toUpperCase(),
+        amountWithTax: Number((order.amount * 1.1).toFixed(2)),
+      };
+    })
+    .into('payload.processed')
+    .collectErrorsInto('payload.failures');
+
+  const resilientLoad = CircuitBreaker.create('warehouse_breaker')
+    .threshold(5)
+    .cooldown(2000)
+    .wrap(
+      Retry.create('load_retry')
+        .attempts(3)
+        .backoff('exponential', { baseMs: 20, factor: 2, jitter: false })
+        .wrap(LoadWarehouseWidget.create('load_warehouse'))
+    );
+
+  extract.moveTo(combine);
+  combine.moveTo(normalize);
+  normalize.moveTo(resilientLoad);
+
+  return Flow.create('resilient_etl').start(extract).end();
+};
+
+let serviceCalls = 0;
+
+class CallFlakyServiceWidget extends CustomWidget {
+  protected async run(): Promise<void> {
+    serviceCalls++;
+    await delay(10);
+    throw new Error('downstream service is down');
+  }
+}
+
+class ServeFromCacheWidget extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.servedFrom = 'cache';
+  }
+}
+
+const buildCircuitBreakerDemo = () => {
+  const breaker = CircuitBreaker.create('downstream_breaker')
+    .threshold(2)
+    .cooldown(5000)
+    .wrap(CallFlakyServiceWidget.create('call_service'))
+    .elseMoveTo(ServeFromCacheWidget.create('serve_cache'));
+
+  return Flow.create('breaker_demo').start(breaker).end();
+};
+
+const runResilientPipeline = async () => {
+  console.log('=== Resilient Parallel ETL ===\n');
+
+  const pipeline = buildResilientPipeline();
+  const result = await pipeline({ batchId: 'BATCH_2026_05' });
+
+  console.log('\nProcessed records:');
+  console.log(JSON.stringify(result.payload.processed, null, 2));
+
+  console.log('\nCollected failures:');
+  console.log(
+    JSON.stringify(
+      result.payload.failures.map((failure: any) => ({
+        index: failure.index,
+        id: failure.item.id,
+        error: String(failure.error),
+      })),
+      null,
+      2
+    )
+  );
+
+  console.log('\nLoad result:');
+  console.log(JSON.stringify(result.payload.loadResult, null, 2));
+};
+
+const runCircuitBreakerDemo = async () => {
+  console.log('\n=== Circuit Breaker Fast-Fail ===\n');
+
+  const demo = buildCircuitBreakerDemo();
+
+  for (let call = 1; call <= 4; call++) {
+    await demo({});
+    console.log(`After call ${call}, the service was hit ${serviceCalls} time(s)`);
+  }
+
+  console.log(
+    '\nThe circuit opened after 2 failures, so calls 3 and 4 never reached the service.'
+  );
+};
+
+const runExample = async () => {
+  await runResilientPipeline();
+  await runCircuitBreakerDemo();
+};
+
+if (require.main === module) {
+  runExample().catch(console.error);
+}
+
+export { buildResilientPipeline, buildCircuitBreakerDemo, runExample };

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "./dist",
-    "noEmit": true
+    "rootDir": "..",
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["./**/*"],
+  "include": ["./**/*", "../src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "declarative-based-flow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Build complex, structured workflows using a declarative and fluent TypeScript syntax. Perfect for ETL pipelines, data validation, and business process automation.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -42,7 +42,7 @@
   "bugs": {
     "url": "https://github.com/iagocalazans/declarative-based-flow/issues"
   },
-  "homepage": "https://github.com/iagocalazans/declarative-based-flow#readme",
+  "homepage": "https://www.npmjs.com/package/declarative-based-flow",
   "author": "Iago Calazans <iago.calazans@gmail.com>",
   "contributors": [
     {

--- a/src/backoff.ts
+++ b/src/backoff.ts
@@ -1,0 +1,43 @@
+import { BackoffOptions, BackoffStrategy } from "./types";
+
+const DEFAULTS: Required<BackoffOptions> = {
+  baseMs: 100,
+  factor: 2,
+  maxMs: 30000,
+  jitter: true,
+};
+
+/**
+ * Computes the wait time before the next retry attempt.
+ *
+ * @param attempt - 1-based index of the attempt that just failed.
+ * @param strategy - `fixed` keeps the base delay; `exponential` grows it by `factor`.
+ * @param options - Backoff tuning options.
+ * @returns Delay in milliseconds, capped at `maxMs` and optionally jittered.
+ */
+export function computeBackoff(
+  attempt: number,
+  strategy: BackoffStrategy,
+  options: BackoffOptions = {},
+): number {
+  const { baseMs, factor, maxMs, jitter } = { ...DEFAULTS, ...options };
+
+  const raw =
+    strategy === "exponential"
+      ? baseMs * Math.pow(factor, Math.max(0, attempt - 1))
+      : baseMs;
+
+  const capped = Math.min(raw, maxMs);
+
+  return jitter ? Math.random() * capped : capped;
+}
+
+/**
+ * Resolves after the given delay.
+ *
+ * @param ms - Milliseconds to wait.
+ * @returns A promise that settles once the delay elapses.
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -1,0 +1,217 @@
+import { isRouteSignal } from "./route-signal";
+import { Widget } from "./widget";
+
+type FailurePredicate = (error: unknown) => boolean;
+type CircuitState = "closed" | "open" | "half-open";
+
+/**
+ * Error thrown when a {@link CircuitBreaker} rejects a call because the circuit
+ * is open. Routes execution to the breaker's failure path.
+ */
+export class CircuitOpenError extends Error {
+  constructor(breaker: string) {
+    super(`Circuit '${breaker}' is open`);
+    this.name = "CircuitOpenError";
+  }
+}
+
+/**
+ * Circuit breaker decorator widget.
+ *
+ * Tracks consecutive failures of a wrapped branch. After `threshold` failures
+ * the circuit opens and calls fast-fail (routing to the failure path) until a
+ * cooldown elapses, at which point a half-open probe decides whether to close.
+ * State lives on the instance, so it is shared across every flow invocation.
+ */
+export class CircuitBreaker extends Widget {
+  private failureThreshold = 5;
+  private cooldownMs = 30000;
+  private halfOpenLimit = 1;
+  private failurePredicate?: FailurePredicate;
+  private inner?: Widget;
+
+  private state: CircuitState = "closed";
+  private consecutiveFailures = 0;
+  private openedAt = 0;
+  private halfOpenInFlight = 0;
+
+  static create(name: string) {
+    return new this(Symbol(name));
+  }
+
+  /**
+   * Connects the success path taken when the wrapped branch succeeds.
+   *
+   * @param widget - Widget to execute on success.
+   * @returns This widget for chaining.
+   */
+  moveTo(widget: Widget) {
+    super.success(widget);
+
+    return this;
+  }
+
+  /**
+   * Connects the failure path, also used as the fallback while the circuit is open.
+   *
+   * @param widget - Widget to execute on failure or short-circuit.
+   * @returns This widget for chaining.
+   */
+  elseMoveTo(widget: Widget) {
+    super.failed(widget);
+
+    return this;
+  }
+
+  /**
+   * Sets how many consecutive failures open the circuit.
+   *
+   * @param count - Failure threshold; defaults to `5`.
+   * @returns This widget for chaining.
+   */
+  threshold(count: number) {
+    this.failureThreshold = count;
+
+    return this;
+  }
+
+  /**
+   * Sets how long the circuit stays open before allowing a half-open probe.
+   *
+   * @param ms - Cooldown in milliseconds; defaults to `30000`.
+   * @returns This widget for chaining.
+   */
+  cooldown(ms: number) {
+    this.cooldownMs = ms;
+
+    return this;
+  }
+
+  /**
+   * Sets how many concurrent probes are allowed while half-open.
+   *
+   * @param count - Probe limit; defaults to `1`.
+   * @returns This widget for chaining.
+   */
+  halfOpenAttempts(count: number) {
+    this.halfOpenLimit = count;
+
+    return this;
+  }
+
+  /**
+   * Restricts which errors count toward opening the circuit. Defaults to any `Error`.
+   *
+   * @param predicate - Returns `true` when the error should count as a failure.
+   * @returns This widget for chaining.
+   */
+  isFailure(predicate: FailurePredicate) {
+    this.failurePredicate = predicate;
+
+    return this;
+  }
+
+  /**
+   * Sets the branch protected by this breaker.
+   *
+   * @param widget - Entry widget of the wrapped branch.
+   * @returns This widget for chaining.
+   */
+  wrap(widget: Widget) {
+    this.inner = widget;
+
+    return this;
+  }
+
+  protected async run(a: any): Promise<void> {
+    if (!this.inner) {
+      throw new Error("To use CircuitBreaker you must set .wrap(widget)");
+    }
+
+    this.refreshState();
+
+    if (this.state === "open" || !this.reserveProbe()) {
+      super.register(
+        `Circuit open, short-circuiting ${this.name.description}`,
+        "warn",
+      );
+
+      throw new CircuitOpenError(this.name.description ?? "unknown");
+    }
+
+    try {
+      await this.inner.process(a);
+      this.recordSuccess();
+    } catch (error) {
+      this.releaseProbe();
+
+      if (isRouteSignal(error)) {
+        throw error;
+      }
+
+      this.recordFailure(error);
+      throw error;
+    }
+  }
+
+  private refreshState(): void {
+    if (
+      this.state === "open" &&
+      Date.now() - this.openedAt >= this.cooldownMs
+    ) {
+      this.state = "half-open";
+      this.halfOpenInFlight = 0;
+    }
+  }
+
+  private reserveProbe(): boolean {
+    if (this.state !== "half-open") {
+      return true;
+    }
+
+    if (this.halfOpenInFlight >= this.halfOpenLimit) {
+      return false;
+    }
+
+    this.halfOpenInFlight++;
+    return true;
+  }
+
+  private releaseProbe(): void {
+    this.halfOpenInFlight = Math.max(0, this.halfOpenInFlight - 1);
+  }
+
+  private recordSuccess(): void {
+    this.releaseProbe();
+    this.consecutiveFailures = 0;
+    this.state = "closed";
+  }
+
+  private recordFailure(error: unknown): void {
+    if (!this.countsAsFailure(error)) {
+      return;
+    }
+
+    this.consecutiveFailures++;
+
+    if (
+      this.state === "half-open" ||
+      this.consecutiveFailures >= this.failureThreshold
+    ) {
+      this.open();
+    }
+  }
+
+  private open(): void {
+    this.state = "open";
+    this.openedAt = Date.now();
+  }
+
+  private countsAsFailure(error: unknown): boolean {
+    if (this.failurePredicate) {
+      return this.failurePredicate(error);
+    }
+
+    return error instanceof Error;
+  }
+}

--- a/src/comparator.ts
+++ b/src/comparator.ts
@@ -1,30 +1,72 @@
+/**
+ * Fluent comparison helper produced by `Compare.is(value)`.
+ *
+ * Each operator returns a boolean, making comparators a natural fit for
+ * `Split.case` predicates.
+ */
 export class Comparator {
   private constructor(private readonly value: any) {}
 
+  /**
+   * Wraps a value to compare against.
+   *
+   * @param value - The left-hand value of the comparison.
+   * @returns A new comparator bound to the value.
+   */
   static create(value: any) {
     return new Comparator(value);
   }
 
+  /**
+   * Strict equality (`===`).
+   *
+   * @param comparator - Value to compare against.
+   */
   equal(comparator: any) {
     return this.value === comparator;
   }
 
+  /**
+   * Strict inequality (`!==`).
+   *
+   * @param comparator - Value to compare against.
+   */
   notEqual(comparator: any) {
-    return this.value === comparator;
+    return this.value !== comparator;
   }
 
+  /**
+   * Membership test against a list.
+   *
+   * @param comparator - Candidate values.
+   */
   in(comparator: any[]) {
     return !!comparator.find((el) => el === this.value);
   }
 
+  /**
+   * Negated membership test against a list.
+   *
+   * @param comparator - Candidate values.
+   */
   notIn(comparator: any[]) {
     return !comparator.find((el) => el === this.value);
   }
 
+  /**
+   * Greater-than comparison (`>`).
+   *
+   * @param comparator - Value to compare against.
+   */
   greaterThan(comparator: any) {
     return this.value > comparator;
   }
 
+  /**
+   * Less-than comparison (`<`).
+   *
+   * @param comparator - Value to compare against.
+   */
   lesserThan(comparator: any) {
     return this.value < comparator;
   }

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,58 @@
+/**
+ * Runs an async task over every item with a bounded number of concurrent executions.
+ *
+ * Results are returned in input order regardless of completion order. On the
+ * first rejection the pool stops scheduling new work, lets in-flight tasks
+ * settle (so no rejection goes unhandled), then rethrows that first error.
+ *
+ * @typeParam T - Item type.
+ * @typeParam R - Result produced per item.
+ * @param items - Items to process.
+ * @param limit - Maximum in-flight tasks; a non-positive value runs all at once.
+ * @param task - Async operation applied to each item.
+ * @returns Ordered array of results.
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+
+  if (items.length === 0) {
+    return results;
+  }
+
+  const effectiveLimit =
+    limit > 0 ? Math.min(limit, items.length) : items.length;
+
+  let cursor = 0;
+  let aborted = false;
+  let firstError: unknown;
+
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length && !aborted) {
+      const index = cursor++;
+
+      try {
+        results[index] = await task(items[index], index);
+      } catch (error) {
+        if (!aborted) {
+          aborted = true;
+          firstError = error;
+        }
+
+        return;
+      }
+    }
+  };
+
+  const workers = Array.from({ length: effectiveLimit }, () => worker());
+  await Promise.all(workers);
+
+  if (aborted) {
+    throw firstError;
+  }
+
+  return results;
+}

--- a/src/custom-widget.ts
+++ b/src/custom-widget.ts
@@ -1,15 +1,34 @@
 import { Widget } from "./widget";
 
+/**
+ * Base class for user-defined widgets.
+ *
+ * Override the protected `run(ctx)` hook to implement business logic; the engine
+ * advances the workflow automatically. Inherits the polymorphic `create`
+ * factory, so subclasses keep their own methods on the created instance.
+ */
 export class CustomWidget extends Widget {
   static create(name: string) {
     return new this(Symbol(name));
   }
 
+  /**
+   * Connects the next widget in the success path.
+   *
+   * @param widget - Widget to execute after this one.
+   * @returns This widget for chaining.
+   */
   moveTo(widget: Widget) {
     super.success(widget);
     return this;
   }
 
+  /**
+   * Connects the widget executed when this widget throws.
+   *
+   * @param widget - Widget to execute on failure.
+   * @returns This widget for chaining.
+   */
   elseMoveTo(widget: Widget) {
     super.failed(widget);
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,20 @@
+export { Widget } from "./widget";
 export { CustomWidget } from "./custom-widget";
 export { Compare } from "./compare";
 export { Flow } from "./flow.class";
 export { SetVariable } from "./set-variable";
 export { Split } from "./split";
+export { Parallel } from "./parallel";
+export { ParallelMap } from "./parallel-map";
+export { Retry } from "./retry";
+export { CircuitBreaker, CircuitOpenError } from "./circuit-breaker";
+export { RouteSignal, isRouteSignal } from "./route-signal";
+export type {
+  WorkflowContext,
+  BackoffStrategy,
+  BackoffOptions,
+  ParallelErrorMode,
+  ItemErrorMode,
+  SettledBranchResult,
+  FailedItem,
+} from "./types";

--- a/src/parallel-map.ts
+++ b/src/parallel-map.ts
@@ -1,0 +1,220 @@
+import { runWithConcurrency } from "./concurrency";
+import { normalizePayloadKey } from "./payload-path";
+import { FailedItem, ItemErrorMode } from "./types";
+import { isValidLabel, processWhiteLabel } from "./validate-whitelabel";
+import { Widget } from "./widget";
+
+type ItemFunction = (item: any, ctx: any) => Promise<any> | any;
+type ItemTask = Widget | ItemFunction;
+type CloneFn = (ctx: any) => any;
+type ItemOutcome = { ok: true; value: any } | { ok: false };
+
+/**
+ * Concurrency-limited batch map widget.
+ *
+ * Maps an async operation over an array resolved from the context, capping the
+ * number of in-flight operations. Successful results are collected in order;
+ * failures are gathered separately, making partial-failure ETL the default.
+ */
+export class ParallelMap extends Widget {
+  private sourcePath?: string;
+  private asKey = "item";
+  private concurrencyLimit = 5;
+  private task?: ItemTask;
+  private intoKey = "processed";
+  private errorMode: ItemErrorMode = "collect";
+  private errorsKey = "failures";
+  private cloneFn: CloneFn = (ctx) => structuredClone(ctx);
+
+  static create(name: string) {
+    return new this(Symbol(name));
+  }
+
+  /**
+   * Connects the success path taken once the batch completes.
+   *
+   * @param widget - Widget to execute after the batch.
+   * @returns This widget for chaining.
+   */
+  moveTo(widget: Widget) {
+    super.success(widget);
+
+    return this;
+  }
+
+  /**
+   * Connects the failure path taken when the batch aborts in `fail-fast` mode.
+   *
+   * @param widget - Widget to execute on failure.
+   * @returns This widget for chaining.
+   */
+  elseMoveTo(widget: Widget) {
+    super.failed(widget);
+
+    return this;
+  }
+
+  /**
+   * Sets the template expression that resolves the source array.
+   *
+   * @param path - Expression such as `'{{ payload.records }}'`.
+   * @returns This widget for chaining.
+   */
+  from(path: string) {
+    this.sourcePath = path;
+
+    return this;
+  }
+
+  /**
+   * Names the payload key under which each item is injected into its clone.
+   *
+   * @param key - Property name (default `'item'`).
+   * @returns This widget for chaining.
+   */
+  as(key: string) {
+    this.asKey = key;
+
+    return this;
+  }
+
+  /**
+   * Caps how many item operations run at once.
+   *
+   * @param limit - Maximum number of in-flight operations (default `5`).
+   * @returns This widget for chaining.
+   */
+  withConcurrency(limit: number) {
+    this.concurrencyLimit = limit;
+
+    return this;
+  }
+
+  /**
+   * Defines the per-item operation.
+   *
+   * @param task - A widget branch executed on a clone, or an async function `(item, ctx) => result`.
+   * @returns This widget for chaining.
+   */
+  each(task: ItemTask) {
+    this.task = task;
+
+    return this;
+  }
+
+  /**
+   * Sets the payload key that collects successful results in input order.
+   *
+   * @param path - Target key, accepting either `'processed'` or `'payload.processed'`.
+   * @returns This widget for chaining.
+   */
+  into(path: string) {
+    this.intoKey = normalizePayloadKey(path);
+
+    return this;
+  }
+
+  /**
+   * Selects failure behavior per item.
+   *
+   * @param mode - `collect` gathers failures (default); `fail-fast` aborts on the first error.
+   * @returns This widget for chaining.
+   */
+  onItemError(mode: ItemErrorMode) {
+    this.errorMode = mode;
+
+    return this;
+  }
+
+  /**
+   * Sets the payload key that collects failed items in `collect` mode.
+   *
+   * @param path - Target key, accepting either `'failures'` or `'payload.failures'`.
+   * @returns This widget for chaining.
+   */
+  collectErrorsInto(path: string) {
+    this.errorsKey = normalizePayloadKey(path);
+
+    return this;
+  }
+
+  /**
+   * Overrides the per-item context cloner (default `structuredClone`).
+   *
+   * @param fn - Custom clone function.
+   * @returns This widget for chaining.
+   */
+  clone(fn: CloneFn) {
+    this.cloneFn = fn;
+
+    return this;
+  }
+
+  protected async run(a: any): Promise<void> {
+    if (!this.sourcePath) {
+      throw new Error(
+        "To use ParallelMap you must set .from('{{ payload.path.to.array }}')",
+      );
+    }
+
+    if (!this.task) {
+      throw new Error(
+        "To use ParallelMap you must set .each(widgetOrFunction)",
+      );
+    }
+
+    const items = this.resolveItems(a);
+    const failures: FailedItem[] = [];
+
+    const outcomes = await runWithConcurrency<any, ItemOutcome>(
+      items,
+      this.concurrencyLimit,
+      async (item, index) => {
+        try {
+          return { ok: true, value: await this.execute(a, item) };
+        } catch (error) {
+          if (this.errorMode === "fail-fast") {
+            throw error;
+          }
+
+          failures.push({ index, item, error });
+          return { ok: false };
+        }
+      },
+    );
+
+    a.payload[this.intoKey] = outcomes
+      .filter((outcome): outcome is { ok: true; value: any } => outcome.ok)
+      .map((outcome) => outcome.value);
+
+    if (this.errorMode === "collect") {
+      a.payload[this.errorsKey] = failures;
+    }
+  }
+
+  private resolveItems(a: any): any[] {
+    const source = isValidLabel(this.sourcePath)
+      ? processWhiteLabel(this.sourcePath as string, a)
+      : undefined;
+
+    if (!Array.isArray(source)) {
+      throw new Error(
+        `ParallelMap source '${this.sourcePath}' did not resolve to an array`,
+      );
+    }
+
+    return source;
+  }
+
+  private async execute(a: any, item: any): Promise<any> {
+    if (this.task instanceof Widget) {
+      const itemCtx = this.cloneFn(a);
+      itemCtx.payload[this.asKey] = item;
+      await this.task.process(itemCtx);
+
+      return itemCtx.payload;
+    }
+
+    return (this.task as ItemFunction)(item, a);
+  }
+}

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,0 +1,216 @@
+import { runWithConcurrency } from "./concurrency";
+import { normalizePayloadKey } from "./payload-path";
+import { ParallelErrorMode, SettledBranchResult } from "./types";
+import { Widget } from "./widget";
+
+type CloneFn = (ctx: any) => any;
+type MergeFn = (ctx: any, results: Record<string, SettledBranchResult>) => void;
+type Branch = { name: string; widget: Widget };
+
+/**
+ * Fan-out / fan-in widget.
+ *
+ * Runs independent named branches concurrently, each on an isolated clone of
+ * the context, then merges their results back. Ideal for multi-source ETL
+ * extraction where several systems are queried at once.
+ */
+export class Parallel extends Widget {
+  private branches: Branch[] = [];
+  private concurrencyLimit = 0;
+  private errorMode: ParallelErrorMode = "fail-fast";
+  private intoKey = "results";
+  private cloneFn: CloneFn = (ctx) => structuredClone(ctx);
+  private mergeFn?: MergeFn;
+
+  static create(name: string) {
+    return new this(Symbol(name));
+  }
+
+  /**
+   * Connects the success path taken once every branch resolves.
+   *
+   * @param widget - Widget to execute after the fan-in completes.
+   * @returns This widget for chaining.
+   */
+  moveTo(widget: Widget) {
+    super.success(widget);
+
+    return this;
+  }
+
+  /**
+   * Connects the failure path taken when the group fails in `fail-fast` mode.
+   *
+   * @param widget - Widget to execute on failure.
+   * @returns This widget for chaining.
+   */
+  elseMoveTo(widget: Widget) {
+    super.failed(widget);
+
+    return this;
+  }
+
+  /**
+   * Registers a concurrently executed branch.
+   *
+   * @param name - Stable key under which the branch result is merged.
+   * @param widget - Entry widget of the branch subtree.
+   * @returns This widget for chaining.
+   */
+  branch(name: string, widget: Widget) {
+    this.branches.push({ name, widget });
+
+    return this;
+  }
+
+  /**
+   * Caps how many branches run at once. Omit (or pass 0) to run all at once.
+   *
+   * @param limit - Maximum number of in-flight branches.
+   * @returns This widget for chaining.
+   */
+  concurrency(limit: number) {
+    this.concurrencyLimit = limit;
+
+    return this;
+  }
+
+  /**
+   * Selects failure behavior for the group.
+   *
+   * @param mode - `fail-fast` aborts on the first rejection; `settle` collects every outcome.
+   * @returns This widget for chaining.
+   */
+  onError(mode: ParallelErrorMode) {
+    this.errorMode = mode;
+
+    return this;
+  }
+
+  /**
+   * Sets the payload key under which branch results are merged.
+   *
+   * @param path - Target key, accepting either `'results'` or `'payload.results'`.
+   * @returns This widget for chaining.
+   */
+  into(path: string) {
+    this.intoKey = normalizePayloadKey(path);
+
+    return this;
+  }
+
+  /**
+   * Overrides the per-branch context cloner (default `structuredClone`).
+   *
+   * Use this when the payload holds values `structuredClone` cannot copy, such
+   * as functions or class instances.
+   *
+   * @param fn - Custom clone function.
+   * @returns This widget for chaining.
+   */
+  clone(fn: CloneFn) {
+    this.cloneFn = fn;
+
+    return this;
+  }
+
+  /**
+   * Replaces the default merge with a custom reducer.
+   *
+   * The reducer receives the parent context and a map of branch outcomes whose
+   * `value` is the resolved branch context.
+   *
+   * @param fn - Custom merge function.
+   * @returns This widget for chaining.
+   */
+  merge(fn: MergeFn) {
+    this.mergeFn = fn;
+
+    return this;
+  }
+
+  protected async run(a: any): Promise<void> {
+    if (this.branches.length === 0) {
+      throw new Error(
+        "To use Parallel you must add at least one .branch(name, widget)",
+      );
+    }
+
+    const settled =
+      this.errorMode === "settle"
+        ? await this.runSettled(a)
+        : await this.runFailFast(a);
+
+    this.commit(a, settled);
+  }
+
+  private async runFailFast(
+    a: any,
+  ): Promise<Record<string, SettledBranchResult>> {
+    const outcomes = await runWithConcurrency(
+      this.branches,
+      this.concurrencyLimit,
+      async ({ name, widget }) => {
+        const branchCtx = this.cloneFn(a);
+        await widget.process(branchCtx);
+
+        return { name, status: "fulfilled", value: branchCtx } as const;
+      },
+    );
+
+    return this.indexByName(outcomes);
+  }
+
+  private async runSettled(
+    a: any,
+  ): Promise<Record<string, SettledBranchResult>> {
+    const outcomes = await runWithConcurrency<Branch, SettledBranchResult>(
+      this.branches,
+      this.concurrencyLimit,
+      async ({ name, widget }) => {
+        const branchCtx = this.cloneFn(a);
+
+        try {
+          await widget.process(branchCtx);
+
+          return { name, status: "fulfilled", value: branchCtx };
+        } catch (error) {
+          return { name, status: "rejected", error };
+        }
+      },
+    );
+
+    return this.indexByName(outcomes);
+  }
+
+  private indexByName(
+    outcomes: SettledBranchResult[],
+  ): Record<string, SettledBranchResult> {
+    const byName: Record<string, SettledBranchResult> = {};
+
+    for (const outcome of outcomes) {
+      byName[outcome.name] = outcome;
+    }
+
+    return byName;
+  }
+
+  private commit(a: any, results: Record<string, SettledBranchResult>): void {
+    if (this.mergeFn) {
+      this.mergeFn(a, results);
+
+      return;
+    }
+
+    const merged: Record<string, any> = {};
+
+    for (const [name, result] of Object.entries(results)) {
+      merged[name] =
+        result.status === "fulfilled"
+          ? (result.value as { payload: unknown }).payload
+          : { error: String(result.error) };
+    }
+
+    a.payload[this.intoKey] = merged;
+  }
+}

--- a/src/payload-path.ts
+++ b/src/payload-path.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalizes a configured target path into a single payload key.
+ *
+ * Accepts both the bare `'results'` form and the `'payload.results'` form so
+ * callers can write whichever reads better.
+ *
+ * @param path - The configured target path.
+ * @returns The key relative to the payload object.
+ */
+export function normalizePayloadKey(path: string): string {
+  return path.startsWith("payload.") ? path.slice("payload.".length) : path;
+}

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,212 @@
+import { computeBackoff, delay } from "./backoff";
+import { isRouteSignal } from "./route-signal";
+import { BackoffOptions, BackoffStrategy } from "./types";
+import { Widget } from "./widget";
+
+type RetryPredicate = (error: unknown) => boolean;
+type CloneFn = (ctx: any) => any;
+
+/**
+ * Retry decorator widget.
+ *
+ * Re-executes a wrapped branch on retryable failures using a configurable
+ * backoff. Routing signals are never retried. When attempts are exhausted the
+ * last error propagates, routing execution to the failure path.
+ */
+export class Retry extends Widget {
+  private maxAttempts = 3;
+  private strategy: BackoffStrategy = "exponential";
+  private backoffOptions: BackoffOptions = {};
+  private predicate?: RetryPredicate;
+  private inner?: Widget;
+  private isolated = false;
+  private cloneFn: CloneFn = (ctx) => structuredClone(ctx);
+
+  static create(name: string) {
+    return new this(Symbol(name));
+  }
+
+  /**
+   * Connects the success path taken once the wrapped branch succeeds.
+   *
+   * @param widget - Widget to execute on success.
+   * @returns This widget for chaining.
+   */
+  moveTo(widget: Widget) {
+    super.success(widget);
+
+    return this;
+  }
+
+  /**
+   * Connects the failure path taken when every attempt fails.
+   *
+   * @param widget - Widget to execute on exhaustion.
+   * @returns This widget for chaining.
+   */
+  elseMoveTo(widget: Widget) {
+    super.failed(widget);
+
+    return this;
+  }
+
+  /**
+   * Sets the maximum number of attempts (including the first).
+   *
+   * @param count - Total attempts; defaults to `3`.
+   * @returns This widget for chaining.
+   */
+  attempts(count: number) {
+    this.maxAttempts = count;
+
+    return this;
+  }
+
+  /**
+   * Configures the backoff used between attempts.
+   *
+   * @param strategy - `fixed` or `exponential`.
+   * @param options - Backoff tuning options.
+   * @returns This widget for chaining.
+   */
+  backoff(strategy: BackoffStrategy, options: BackoffOptions = {}) {
+    this.strategy = strategy;
+    this.backoffOptions = options;
+
+    return this;
+  }
+
+  /**
+   * Restricts which errors are retryable. Defaults to any `Error`.
+   *
+   * @param predicate - Returns `true` when the error should be retried.
+   * @returns This widget for chaining.
+   */
+  retryIf(predicate: RetryPredicate) {
+    this.predicate = predicate;
+
+    return this;
+  }
+
+  /**
+   * Runs each attempt on a fresh clone, committing mutations only on success.
+   *
+   * Use this when the wrapped branch is not naturally idempotent (for example
+   * when it defines variables), since variables cannot be redefined in place.
+   *
+   * @returns This widget for chaining.
+   */
+  isolate() {
+    this.isolated = true;
+
+    return this;
+  }
+
+  /**
+   * Overrides the clone function used by {@link Retry.isolate}.
+   *
+   * @param fn - Custom clone function.
+   * @returns This widget for chaining.
+   */
+  clone(fn: CloneFn) {
+    this.cloneFn = fn;
+
+    return this;
+  }
+
+  /**
+   * Sets the branch to execute with retry semantics.
+   *
+   * @param widget - Entry widget of the wrapped branch.
+   * @returns This widget for chaining.
+   */
+  wrap(widget: Widget) {
+    this.inner = widget;
+
+    return this;
+  }
+
+  protected async run(a: any): Promise<void> {
+    if (!this.inner) {
+      throw new Error("To use Retry you must set .wrap(widget)");
+    }
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      try {
+        await this.attempt(a);
+
+        return;
+      } catch (error) {
+        if (isRouteSignal(error)) {
+          throw error;
+        }
+
+        lastError = error;
+
+        if (attempt >= this.maxAttempts || !this.isRetryable(error)) {
+          throw error;
+        }
+
+        super.register(
+          `Attempt ${attempt}/${this.maxAttempts} failed, retrying`,
+          "warn",
+        );
+
+        await delay(
+          computeBackoff(attempt, this.strategy, this.backoffOptions),
+        );
+      }
+    }
+
+    throw lastError;
+  }
+
+  private async attempt(a: any): Promise<void> {
+    if (!this.isolated) {
+      await (this.inner as Widget).process(a);
+
+      return;
+    }
+
+    const attemptCtx = this.cloneFn(a);
+    await (this.inner as Widget).process(attemptCtx);
+    this.commit(a, attemptCtx);
+  }
+
+  private commit(a: any, attemptCtx: any): void {
+    Object.assign(a.payload, attemptCtx.payload);
+
+    if (!attemptCtx.variables) {
+      return;
+    }
+
+    if (!Reflect.has(a, "variables")) {
+      Reflect.defineProperty(a, "variables", {
+        configurable: true,
+        enumerable: true,
+        value: {},
+      });
+    }
+
+    for (const [key, value] of Object.entries(attemptCtx.variables)) {
+      if (!Reflect.has(a.variables, key)) {
+        Reflect.defineProperty(a.variables, key, {
+          configurable: false,
+          writable: false,
+          enumerable: true,
+          value,
+        });
+      }
+    }
+  }
+
+  private isRetryable(error: unknown): boolean {
+    if (this.predicate) {
+      return this.predicate(error);
+    }
+
+    return error instanceof Error;
+  }
+}

--- a/src/route-signal.ts
+++ b/src/route-signal.ts
@@ -1,0 +1,24 @@
+/**
+ * Control-flow marker used to route execution to a widget's failure path
+ * without representing an operational error.
+ *
+ * It is intentionally not an `Error` subclass so that resilience widgets which
+ * inspect `error instanceof Error` ignore routing decisions automatically and
+ * never retry or count them as failures.
+ */
+export class RouteSignal {
+  /**
+   * @param reason - Short, machine-readable description of why routing occurred.
+   */
+  constructor(readonly reason: string) {}
+}
+
+/**
+ * Type guard that detects a {@link RouteSignal}.
+ *
+ * @param value - The caught value to inspect.
+ * @returns `true` when the value is a routing signal rather than a real error.
+ */
+export function isRouteSignal(value: unknown): value is RouteSignal {
+  return value instanceof RouteSignal;
+}

--- a/src/set-variable.ts
+++ b/src/set-variable.ts
@@ -1,42 +1,55 @@
 import { isValidLabel, processWhiteLabel } from "./validate-whitelabel";
 import { Widget } from "./widget";
 
+type VariableAction = {
+  var: string;
+  use: unknown;
+};
+
+/**
+ * Variable extraction widget.
+ *
+ * Resolves one or more template expressions (`{{ payload.path.to.value }}`) or
+ * literal values and stores each as an immutable entry on the context's
+ * `variables` bag. Multiple `variable()` calls accumulate, so a single widget
+ * can extract several values.
+ */
 export class SetVariable extends Widget {
-  private action: {
-    set: {
-      var?: string;
-      use?: unknown;
-    };
-  } = {
-    set: {
-      var: undefined,
-      use: undefined,
-    },
-  };
+  private actions: VariableAction[] = [];
 
   static create(name: string) {
     return new this(Symbol(name));
   }
 
+  /**
+   * Connects the next widget in the success path.
+   *
+   * @param widget - Widget to execute after this one.
+   * @returns This widget for chaining.
+   */
   moveTo(widget: Widget) {
     super.success(widget);
 
     return this;
   }
 
+  /**
+   * Declares a variable to extract. Can be called multiple times.
+   *
+   * @param varName - Name of the variable to store on `variables`.
+   * @param whitelabel - Template expression to resolve, or a literal value.
+   * @returns This widget for chaining.
+   */
   variable(varName: string, whitelabel: string) {
-    this.action.set = {
-      var: varName,
-      use: whitelabel,
-    };
+    this.actions.push({ var: varName, use: whitelabel });
 
     return this;
   }
 
-  async process(a: any): Promise<any> {
-    if (!this.action.set.use || !this.action.set.var) {
+  protected async run(a: any): Promise<void> {
+    if (this.actions.length === 0) {
       throw new Error(
-        'To use SetVariable you must set .add("varName", "{{ whitelabel.to.use }}")'
+        'To use SetVariable you must set .variable("varName", "{{ whitelabel.to.use }}")'
       );
     }
 
@@ -48,22 +61,19 @@ export class SetVariable extends Widget {
       });
     }
 
-    const parsedValue = isValidLabel(this.action.set.use)
-      ? processWhiteLabel(this.action.set.use as string, a)
-      : this.action.set.use;
+    for (const action of this.actions) {
+      const parsedValue = isValidLabel(action.use)
+        ? processWhiteLabel(action.use as string, a)
+        : action.use;
 
-    Reflect.defineProperty(a.variables, this.action.set.var, {
-      configurable: false,
-      writable: false,
-      enumerable: true,
-      value: parsedValue,
-    });
+      Reflect.defineProperty(a.variables, action.var, {
+        configurable: false,
+        writable: false,
+        enumerable: true,
+        value: parsedValue,
+      });
 
-    super.register(
-      `Defined var ${this.action.set.var} = ${parsedValue}`,
-      "info"
-    );
-
-    super.process(a);
+      super.register(`Defined var ${action.var} = ${parsedValue}`, "info");
+    }
   }
 }

--- a/src/split.ts
+++ b/src/split.ts
@@ -1,5 +1,13 @@
+import { RouteSignal } from "./route-signal";
 import { Widget } from "./widget";
 
+/**
+ * Conditional branching widget.
+ *
+ * Evaluates a boolean predicate against the workflow context. A truthy result
+ * continues down the `moveTo` path; a falsy result throws a {@link RouteSignal}
+ * so execution routes to the `elseMoveTo` path without being treated as an error.
+ */
 export class Split extends Widget {
   private action: {
     fn?: (a: any) => boolean;
@@ -11,39 +19,55 @@ export class Split extends Widget {
     return new this(Symbol(name));
   }
 
+  /**
+   * Connects the path taken when the predicate is truthy.
+   *
+   * @param widget - Widget to execute on a positive match.
+   * @returns This widget for chaining.
+   */
   moveTo(widget: Widget) {
     super.success(widget);
 
     return this;
   }
 
+  /**
+   * Connects the path taken when the predicate is falsy.
+   *
+   * @param widget - Widget to execute on a negative match.
+   * @returns This widget for chaining.
+   */
   elseMoveTo(widget: Widget) {
     super.failed(widget);
 
     return this;
   }
 
+  /**
+   * Defines the predicate that decides which branch to follow.
+   *
+   * @param fn - Function receiving the context and returning a boolean.
+   * @returns This widget for chaining.
+   */
   case(fn: (a: any) => boolean) {
     this.action.fn = fn;
 
     return this;
   }
 
-  async process(a: any): Promise<any> {
+  protected async run(a: any): Promise<void> {
     if (!this.action.fn) {
       throw new Error(
-        "To use Split you must set a .case((data: any) => Compare.is(data.payload.act.like.that).in(['this', 'those', 'that'])"
+        "To use Split you must set a .case((data: any) => Compare.is(data.payload.act.like.that).in(['this', 'those', 'that'])",
       );
     }
 
-    if (this.action.fn(a) === true) {
+    if (this.action.fn(a)) {
       super.register(`Moved to: ${this.moveToName}`, "info");
-      await super.process(a);
+      return;
     }
 
-    if (this.action.fn(a) === false) {
-      super.register(`Moved to: ${this.elseMoveToName}`, "info");
-      throw "force right side";
-    }
+    super.register(`Moved to: ${this.elseMoveToName}`, "info");
+    throw new RouteSignal("split:else");
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Canonical data structure that flows through every widget.
+ *
+ * @typeParam P - Shape of the mutable payload object.
+ * @typeParam V - Shape of the immutable variables bag populated by `SetVariable`.
+ */
+export interface WorkflowContext<
+  P extends Record<string, any> = Record<string, any>,
+  V extends Record<string, any> = Record<string, any>,
+> {
+  payload: P;
+  variables?: V;
+}
+
+/**
+ * Strategy used to compute the wait time between retry attempts.
+ */
+export type BackoffStrategy = "fixed" | "exponential";
+
+/**
+ * Tuning options for backoff calculation.
+ */
+export interface BackoffOptions {
+  /** Base delay in milliseconds applied to the first retryable failure. */
+  baseMs?: number;
+  /** Multiplier applied per attempt when using the `exponential` strategy. */
+  factor?: number;
+  /** Upper bound in milliseconds that a computed delay can never exceed. */
+  maxMs?: number;
+  /** When `true`, applies full jitter to spread retries and avoid thundering herds. */
+  jitter?: boolean;
+}
+
+/**
+ * Determines how a `Parallel` widget reacts when one of its branches throws.
+ *
+ * - `fail-fast`: the first rejection aborts the group and routes to the failure path.
+ * - `settle`: every branch runs to completion and outcomes are collected, never throwing.
+ */
+export type ParallelErrorMode = "fail-fast" | "settle";
+
+/**
+ * Determines how a `ParallelMap` widget reacts when an item operation throws.
+ *
+ * - `collect`: failures are gathered into a separate bucket (partial-failure ETL).
+ * - `fail-fast`: the first item error aborts the batch and routes to the failure path.
+ */
+export type ItemErrorMode = "collect" | "fail-fast";
+
+/**
+ * Outcome of a single branch when a `Parallel` widget runs in `settle` mode.
+ */
+export interface SettledBranchResult {
+  name: string;
+  status: "fulfilled" | "rejected";
+  value?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Record describing a single item that failed during a `ParallelMap` batch.
+ *
+ * @typeParam T - Type of the item that failed.
+ */
+export interface FailedItem<T = unknown> {
+  index: number;
+  item: T;
+  error: unknown;
+}

--- a/src/validate-whitelabel.ts
+++ b/src/validate-whitelabel.ts
@@ -1,7 +1,7 @@
 function findObjectValue<T extends Record<string, any>>(
   object: T,
   keys: [keyof T],
-  index = 0
+  index = 0,
 ) {
   if (index < keys.length - 1 && Reflect.has(object, keys[index])) {
     const prop = Reflect.get(object, keys[index]);
@@ -28,7 +28,7 @@ function useWhiteLabel<T extends Record<string, any>>(label: string) {
 
 export function processWhiteLabel<T extends Record<string, any>>(
   label: string,
-  object: T
+  object: T,
 ) {
   return findObjectValue(object, useWhiteLabel<T>(label));
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,18 +1,38 @@
+import { isRouteSignal } from "./route-signal";
+
+/**
+ * Base node of the workflow tree.
+ *
+ * Every widget owns a success pointer (`left`, reached via `moveTo`) and a
+ * failure pointer (`right`, reached via `elseMoveTo`). Execution is driven by
+ * the Template Method {@link Widget.process}: it runs the widget's own
+ * operation through {@link Widget.run}, then advances into the success branch,
+ * routing thrown values to the failure branch when one exists.
+ */
 export class Widget {
   protected constructor(
     protected readonly uniqueName: symbol,
     private left?: Widget,
-    private right?: Widget
+    private right?: Widget,
   ) {}
 
+  /**
+   * Unique symbol identifying this widget instance.
+   */
   get name() {
     return this.uniqueName;
   }
 
+  /**
+   * Description of the success-path widget, when connected.
+   */
   get moveToName() {
     return this.left?.name.description;
   }
 
+  /**
+   * Description of the failure-path widget, when connected.
+   */
   get elseMoveToName() {
     return this.right?.name.description;
   }
@@ -25,6 +45,16 @@ export class Widget {
     this.right = widget;
   }
 
+  /**
+   * Creates a widget with a unique symbolic name.
+   *
+   * A subclass that adds its own configuration methods should re-declare this
+   * factory so the returned type exposes them, matching the pattern used by the
+   * built-in widgets.
+   *
+   * @param name - Human-readable identifier for the widget.
+   * @returns A new widget instance ready to be connected.
+   */
   static create(name: string) {
     return new this(Symbol(name));
   }
@@ -43,38 +73,68 @@ export class Widget {
 
   protected register(
     a: any,
-    level: keyof Pick<Console, "debug" | "log" | "info" | "error" | "warn"> = "log"
+    level: keyof Pick<
+      Console,
+      "debug" | "log" | "info" | "error" | "warn"
+    > = "log",
   ): void {
-    // TODO: Must optmize debugging log
-
     if (level !== "debug" && process.env.ENV !== "development") {
       console[level](
         `[${this.constructor.name}: ${
           this.uniqueName.description
-        }]: => ${JSON.stringify(a, null, 2)}`
+        }]: => ${JSON.stringify(a, null, 2)}`,
       );
     }
   }
 
+  /**
+   * Widget-specific operation. Concrete widgets override this hook to perform
+   * their work. Throwing here routes execution to this widget's failure path.
+   *
+   * @param _ctx - The workflow context (payload and variables).
+   */
+  protected async run(_ctx: any): Promise<void> {}
+
+  /**
+   * Executes this widget and the rest of the connected tree.
+   *
+   * Wraps a bare input into `{ payload }`, runs this widget's operation, then
+   * advances into the success branch. The returned context is fully resolved:
+   * every downstream widget is awaited before this method settles.
+   *
+   * @param a - Raw input on entry, or an already-wrapped workflow context.
+   * @returns The resolved workflow context.
+   */
   async process(a: any) {
     if (!Reflect.has(a, "payload")) {
-      const payload = a;
-      a = { payload: payload };
-      // Note: payload is NOT frozen to allow widgets to add new properties
-      // Original input properties remain, but widgets can extend the payload
+      a = { payload: a };
     }
 
-    try {
-      if (this.left) {
-        await this.left?.process(a);
-      }
-    } catch {
-      if (this.left?.right) {
-        await this.left?.right.process(a);
-      }
-    }
+    await this.run(a);
+    await this.traverse(a);
 
     this.register(a, "debug");
     return a;
+  }
+
+  private async traverse(a: any): Promise<void> {
+    if (!this.left) {
+      return;
+    }
+
+    try {
+      await this.left.process(a);
+    } catch (error) {
+      if (this.left.right) {
+        await this.left.right.process(a);
+        return;
+      }
+
+      if (isRouteSignal(error)) {
+        return;
+      }
+
+      throw error;
+    }
   }
 }

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -1,0 +1,63 @@
+import { CircuitBreaker, CustomWidget, Flow } from "../src";
+
+let shouldFail = true;
+let calls = 0;
+
+class Toggle extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    calls++;
+    if (shouldFail) {
+      throw new Error("down");
+    }
+    data.payload.ok = true;
+  }
+}
+
+class Succeeded extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.succeeded = true;
+  }
+}
+
+class FellBack extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.fellBack = true;
+  }
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("CircuitBreaker widget", () => {
+  it("opens after the threshold, short-circuits, then recovers via half-open", async () => {
+    shouldFail = true;
+    calls = 0;
+
+    const breaker = CircuitBreaker.create("api_breaker")
+      .threshold(2)
+      .cooldown(30)
+      .wrap(Toggle.create("api"))
+      .moveTo(Succeeded.create("succeeded"))
+      .elseMoveTo(FellBack.create("fell_back"));
+
+    const flow = Flow.create("breaker_flow").start(breaker).end();
+
+    const first = await flow({});
+    expect(first.payload.fellBack).toBe(true);
+    expect(calls).toBe(1);
+
+    const second = await flow({});
+    expect(second.payload.fellBack).toBe(true);
+    expect(calls).toBe(2);
+
+    const third = await flow({});
+    expect(third.payload.fellBack).toBe(true);
+    expect(calls).toBe(2);
+
+    await delay(80);
+    shouldFail = false;
+
+    const fourth = await flow({});
+    expect(fourth.payload.succeeded).toBe(true);
+    expect(calls).toBe(3);
+  });
+});

--- a/test/comparator.test.ts
+++ b/test/comparator.test.ts
@@ -1,0 +1,27 @@
+import { Compare } from "../src";
+
+describe("Comparator", () => {
+  it("equal returns true only on strict equality", () => {
+    expect(Compare.is(5).equal(5)).toBe(true);
+    expect(Compare.is(5).equal(6)).toBe(false);
+  });
+
+  it("notEqual returns true when values differ", () => {
+    expect(Compare.is(5).notEqual(6)).toBe(true);
+    expect(Compare.is(5).notEqual(5)).toBe(false);
+  });
+
+  it("in and notIn check membership", () => {
+    expect(Compare.is("a").in(["a", "b"])).toBe(true);
+    expect(Compare.is("z").in(["a", "b"])).toBe(false);
+    expect(Compare.is("z").notIn(["a", "b"])).toBe(true);
+    expect(Compare.is("a").notIn(["a", "b"])).toBe(false);
+  });
+
+  it("greaterThan and lesserThan compare values", () => {
+    expect(Compare.is(10).greaterThan(5)).toBe(true);
+    expect(Compare.is(3).greaterThan(5)).toBe(false);
+    expect(Compare.is(3).lesserThan(5)).toBe(true);
+    expect(Compare.is(8).lesserThan(5)).toBe(false);
+  });
+});

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -1,5 +1,5 @@
 import { SetVariable } from "../src";
 
-export const amazingSetVariableWidgetOne = SetVariable
-        .create('amazing_set_variable_widget_one')
-        .variable('myVarOne', '{{ payload.act.like.that }}');
+export const amazingSetVariableWidgetOne = SetVariable.create(
+  "amazing_set_variable_widget_one",
+).variable("myVarOne", "{{ payload.act.like.that }}");

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -1,20 +1,20 @@
-import { Flow } from '../src';
-import { amazingSetVariableWidgetOne } from './consts';
+import { Flow } from "../src";
+import { amazingSetVariableWidgetOne } from "./consts";
 
+describe("Flow specs", () => {
+  it("should be created as a class with an unique name", () => {
+    const amazingFlow = Flow.create("amazing_flow");
+    const uniqueName = Symbol.for("amazing_flow");
 
-describe('Flow specs', () => {
-    it('should be created as a class with an unique name', () => {
-        const amazingFlow = Flow.create('amazing_flow');
-        const uniqueName = Symbol.for('amazing_flow');
+    expect(amazingFlow).toBeInstanceOf(Flow);
+    expect(amazingFlow.name.toString()).toBe(uniqueName.toString());
+  });
 
-        expect(amazingFlow).toBeInstanceOf(Flow);
-        expect(amazingFlow.name.toString()).toBe(uniqueName.toString())
-    })
+  it("should return the process method as extended function", () => {
+    const flow = Flow.create("amazing_flow")
+      .start(amazingSetVariableWidgetOne)
+      .end();
 
-    it('should return the process method as extended function', () => {
-        
-        const flow = Flow.create('amazing_flow').start(amazingSetVariableWidgetOne).end();
-
-        expect(flow.toString()).toBe(Flow.prototype.process.bind(Flow).toString())
-    })
+    expect(flow.toString()).toBe(Flow.prototype.process.bind(Flow).toString());
+  });
 });

--- a/test/parallel-map.test.ts
+++ b/test/parallel-map.test.ts
@@ -1,0 +1,100 @@
+import { CustomWidget, Flow, ParallelMap } from "../src";
+
+let inFlight = 0;
+let maxInFlight = 0;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class Doubler extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.doubled = data.payload.item * 2;
+  }
+}
+
+describe("ParallelMap widget", () => {
+  beforeEach(() => {
+    inFlight = 0;
+    maxInFlight = 0;
+  });
+
+  it("maps over items with a concurrency cap, preserving order", async () => {
+    const map = ParallelMap.create("transform")
+      .from("{{ payload.numbers }}")
+      .withConcurrency(2)
+      .each(async (item: number) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        try {
+          await delay(10);
+          return item * 10;
+        } finally {
+          inFlight--;
+        }
+      });
+
+    const flow = Flow.create("map_flow").start(map).end();
+
+    const result = await flow({ numbers: [1, 2, 3, 4, 5] });
+
+    expect(maxInFlight).toBe(2);
+    expect(result.payload.processed).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it("collects failures while keeping successful results in order", async () => {
+    const map = ParallelMap.create("transform")
+      .from("{{ payload.numbers }}")
+      .withConcurrency(2)
+      .each(async (item: number) => {
+        if (item === 3) {
+          throw new Error("bad-3");
+        }
+        return item * 10;
+      });
+
+    const flow = Flow.create("partial_flow").start(map).end();
+
+    const result = await flow({ numbers: [1, 2, 3, 4, 5] });
+
+    expect(result.payload.processed).toEqual([10, 20, 40, 50]);
+    expect(result.payload.failures).toHaveLength(1);
+    expect(result.payload.failures[0].index).toBe(2);
+    expect(result.payload.failures[0].item).toBe(3);
+  });
+
+  it("aborts and routes to the failure path in fail-fast mode", async () => {
+    const recover = class extends CustomWidget {
+      protected async run(data: any): Promise<void> {
+        data.payload.recovered = true;
+      }
+    }.create("recover");
+
+    const map = ParallelMap.create("transform")
+      .from("{{ payload.numbers }}")
+      .each(async (item: number) => {
+        if (item === 2) {
+          throw new Error("stop");
+        }
+        return item;
+      })
+      .onItemError("fail-fast")
+      .elseMoveTo(recover);
+
+    const flow = Flow.create("fail_fast_map").start(map).end();
+
+    const result = await flow({ numbers: [1, 2, 3] });
+
+    expect(result.payload.recovered).toBe(true);
+  });
+
+  it("runs a widget branch per item when given a widget", async () => {
+    const map = ParallelMap.create("transform")
+      .from("{{ payload.numbers }}")
+      .each(Doubler.create("doubler"));
+
+    const flow = Flow.create("widget_map").start(map).end();
+
+    const result = await flow({ numbers: [2, 4] });
+
+    expect(result.payload.processed.map((p: any) => p.doubled)).toEqual([4, 8]);
+  });
+});

--- a/test/parallel.test.ts
+++ b/test/parallel.test.ts
@@ -1,0 +1,92 @@
+import { CustomWidget, Flow, Parallel } from "../src";
+
+let inFlight = 0;
+let maxInFlight = 0;
+
+class Tagger extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    inFlight--;
+    data.payload.tag = this.name.description;
+  }
+}
+
+class Exploder extends CustomWidget {
+  protected async run(): Promise<void> {
+    throw new Error("branch failed");
+  }
+}
+
+class Recover extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.recovered = true;
+  }
+}
+
+describe("Parallel widget", () => {
+  beforeEach(() => {
+    inFlight = 0;
+    maxInFlight = 0;
+  });
+
+  it("runs branches concurrently and merges results by name", async () => {
+    const parallel = Parallel.create("fan_out")
+      .branch("a", Tagger.create("branch_a"))
+      .branch("b", Tagger.create("branch_b"))
+      .branch("c", Tagger.create("branch_c"))
+      .into("payload.sources");
+
+    const flow = Flow.create("parallel_flow").start(parallel).end();
+
+    const result = await flow({ seed: 1 });
+
+    expect(maxInFlight).toBe(3);
+    expect(result.payload.sources.a.tag).toBe("branch_a");
+    expect(result.payload.sources.b.tag).toBe("branch_b");
+    expect(result.payload.sources.c.tag).toBe("branch_c");
+  });
+
+  it("respects the concurrency cap", async () => {
+    const parallel = Parallel.create("capped")
+      .branch("a", Tagger.create("branch_a"))
+      .branch("b", Tagger.create("branch_b"))
+      .branch("c", Tagger.create("branch_c"))
+      .concurrency(1);
+
+    const flow = Flow.create("capped_flow").start(parallel).end();
+
+    await flow({});
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("routes to the failure path when a branch fails in fail-fast mode", async () => {
+    const parallel = Parallel.create("fail_fast")
+      .branch("ok", Tagger.create("branch_ok"))
+      .branch("bad", Exploder.create("branch_bad"))
+      .elseMoveTo(Recover.create("recover"));
+
+    const flow = Flow.create("fail_fast_flow").start(parallel).end();
+
+    const result = await flow({});
+
+    expect(result.payload.recovered).toBe(true);
+  });
+
+  it("collects every outcome in settle mode", async () => {
+    const parallel = Parallel.create("settle")
+      .branch("ok", Tagger.create("branch_ok"))
+      .branch("bad", Exploder.create("branch_bad"))
+      .onError("settle")
+      .into("payload.sources");
+
+    const flow = Flow.create("settle_flow").start(parallel).end();
+
+    const result = await flow({});
+
+    expect(result.payload.sources.ok.tag).toBe("branch_ok");
+    expect(result.payload.sources.bad.error).toContain("branch failed");
+  });
+});

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,119 @@
+import { CustomWidget, Flow, Retry, RouteSignal } from "../src";
+import { computeBackoff } from "../src/backoff";
+
+let attemptCount = 0;
+
+class FlakyLoad extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    attemptCount++;
+    if (attemptCount < 3) {
+      throw new Error("transient");
+    }
+    data.payload.loaded = true;
+  }
+}
+
+class AlwaysFails extends CustomWidget {
+  protected async run(): Promise<void> {
+    attemptCount++;
+    throw new Error("permanent");
+  }
+}
+
+class RouteOut extends CustomWidget {
+  protected async run(): Promise<void> {
+    attemptCount++;
+    throw new RouteSignal("test:else");
+  }
+}
+
+class Recover extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.recovered = true;
+  }
+}
+
+describe("Retry widget", () => {
+  beforeEach(() => {
+    attemptCount = 0;
+  });
+
+  it("retries until the wrapped branch succeeds", async () => {
+    const retry = Retry.create("retry_load")
+      .attempts(3)
+      .backoff("fixed", { baseMs: 1, jitter: false })
+      .wrap(FlakyLoad.create("load"));
+
+    const flow = Flow.create("retry_flow").start(retry).end();
+
+    const result = await flow({});
+
+    expect(attemptCount).toBe(3);
+    expect(result.payload.loaded).toBe(true);
+  });
+
+  it("routes to the failure path after exhausting attempts", async () => {
+    const retry = Retry.create("retry_exhaust")
+      .attempts(2)
+      .backoff("fixed", { baseMs: 1, jitter: false })
+      .wrap(AlwaysFails.create("load"))
+      .elseMoveTo(Recover.create("recover"));
+
+    const flow = Flow.create("retry_exhaust_flow").start(retry).end();
+
+    const result = await flow({});
+
+    expect(attemptCount).toBe(2);
+    expect(result.payload.recovered).toBe(true);
+  });
+
+  it("never retries routing signals", async () => {
+    const retry = Retry.create("retry_route")
+      .attempts(3)
+      .wrap(RouteOut.create("route"))
+      .elseMoveTo(Recover.create("recover"));
+
+    const flow = Flow.create("retry_route_flow").start(retry).end();
+
+    const result = await flow({});
+
+    expect(attemptCount).toBe(1);
+    expect(result.payload.recovered).toBe(true);
+  });
+
+  it("respects a custom retryIf predicate", async () => {
+    const retry = Retry.create("retry_predicate")
+      .attempts(5)
+      .backoff("fixed", { baseMs: 1, jitter: false })
+      .retryIf(
+        (error) => error instanceof Error && error.message === "transient",
+      )
+      .wrap(AlwaysFails.create("load"))
+      .elseMoveTo(Recover.create("recover"));
+
+    const flow = Flow.create("retry_predicate_flow").start(retry).end();
+
+    const result = await flow({});
+
+    expect(attemptCount).toBe(1);
+    expect(result.payload.recovered).toBe(true);
+  });
+});
+
+describe("computeBackoff", () => {
+  it("grows exponentially and respects the cap", () => {
+    const options = { baseMs: 100, factor: 2, maxMs: 1000, jitter: false };
+
+    expect(computeBackoff(1, "exponential", options)).toBe(100);
+    expect(computeBackoff(2, "exponential", options)).toBe(200);
+    expect(computeBackoff(3, "exponential", options)).toBe(400);
+    expect(computeBackoff(10, "exponential", options)).toBe(1000);
+  });
+
+  it("keeps a constant delay for the fixed strategy", () => {
+    const options = { baseMs: 50, jitter: false };
+
+    expect(computeBackoff(1, "fixed", options)).toBe(50);
+    expect(computeBackoff(5, "fixed", options)).toBe(50);
+  });
+});

--- a/test/set-variable.test.ts
+++ b/test/set-variable.test.ts
@@ -1,67 +1,88 @@
 import { SetVariable, Flow } from "../src";
-import { amazingSetVariableWidgetOne } from './consts';
+import { amazingSetVariableWidgetOne } from "./consts";
 
-describe('Receives SetVariable widget\'s', () => {
-    let flow: (a: any) => any;
-    
-    beforeAll(() => {
-        amazingSetVariableWidgetOne.moveTo(
-            SetVariable
-                .create('amazing_set_variable_widget_two')
-                .variable('myVarTwo', '{{ payload.act.like.this.should.be.this }}')
-                .moveTo(
-                    SetVariable
-                        .create('amazing_set_variable_widget_three')
-                        .variable('myVarThree', '{{ payload.act.like.those }}')
-                    )
-            );
-        
-        flow = Flow.create('amazing_flow').start(amazingSetVariableWidgetOne).end();
-    })
+describe("Receives SetVariable widget's", () => {
+  let flow: (a: any) => any;
 
-    it('should create a SetVariable widget', () => {
-        const widget = SetVariable.create('amazing_set_variable_widget');
-        expect(widget).toBeInstanceOf(SetVariable);
-    })
-    
-    it('should run with three SetVariable widget\'s', () => {
-        const payload = flow({
-            act: {
-                like: { 
-                    that: 'that', 
-                    this: { 
-                        should: { 
-                            be: { 
-                                this:'this' 
-                            } 
-                        } 
-                    }, 
-                    those: 'those' 
-                }
-            }
-        });
+  beforeAll(() => {
+    amazingSetVariableWidgetOne.moveTo(
+      SetVariable.create("amazing_set_variable_widget_two")
+        .variable("myVarTwo", "{{ payload.act.like.this.should.be.this }}")
+        .moveTo(
+          SetVariable.create("amazing_set_variable_widget_three").variable(
+            "myVarThree",
+            "{{ payload.act.like.those }}",
+          ),
+        ),
+    );
 
-        expect(payload).resolves.toMatchObject({
-            payload: {
-                act: {
-                    like: { 
-                        that: 'that', 
-                        this: { 
-                            should: { 
-                                be: { 
-                                    this:'this' 
-                                } 
-                            } 
-                        }, 
-                        those: 'those' 
-                    }
-                }
+    flow = Flow.create("amazing_flow").start(amazingSetVariableWidgetOne).end();
+  });
+
+  it("should create a SetVariable widget", () => {
+    const widget = SetVariable.create("amazing_set_variable_widget");
+    expect(widget).toBeInstanceOf(SetVariable);
+  });
+
+  it("should run with three SetVariable widget's", () => {
+    const payload = flow({
+      act: {
+        like: {
+          that: "that",
+          this: {
+            should: {
+              be: {
+                this: "this",
+              },
             },
-            variables: { 
-                myVarOne: 'that', 
-                myVarTwo: 'this', 
-                myVarThree: 'those' 
-            }
-        });
+          },
+          those: "those",
+        },
+      },
     });
+
+    expect(payload).resolves.toMatchObject({
+      payload: {
+        act: {
+          like: {
+            that: "that",
+            this: {
+              should: {
+                be: {
+                  this: "this",
+                },
+              },
+            },
+            those: "those",
+          },
+        },
+      },
+      variables: {
+        myVarOne: "that",
+        myVarTwo: "this",
+        myVarThree: "those",
+      },
+    });
+  });
+});
+
+describe("SetVariable with multiple variables on one widget", () => {
+  it("accumulates every declared variable", async () => {
+    const extract = SetVariable.create("extract_many")
+      .variable("id", "{{ payload.user.id }}")
+      .variable("email", "{{ payload.user.email }}")
+      .variable("tier", "{{ payload.user.tier }}");
+
+    const flow = Flow.create("multi_var_flow").start(extract).end();
+
+    const result = await flow({
+      user: { id: 7, email: "a@b.com", tier: "gold" },
+    });
+
+    expect(result.variables).toMatchObject({
+      id: 7,
+      email: "a@b.com",
+      tier: "gold",
+    });
+  });
 });

--- a/test/split.test.ts
+++ b/test/split.test.ts
@@ -1,89 +1,89 @@
 import { Split, Compare, SetVariable, Flow } from "../src";
-import { amazingSetVariableWidgetOne } from './consts';
+import { amazingSetVariableWidgetOne } from "./consts";
 
-describe('Receives Split widget\'s', () => {
-    let flow: (a: any) => any;
-    
-    beforeAll(() => {
-        amazingSetVariableWidgetOne.moveTo(
-            Split
-                .create('amazing_split_widget')
-                .case((data: any) => Compare
-                    .is(data.payload.act.like.that)
-                    .in(['this', 'those', 'that'])
-                )
-                .moveTo(
-                    SetVariable
-                        .create('amazing_set_variable_widget_three')
-                        .variable('myVarThree', '{{ payload.act.like.those }}')
-                )
-                .elseMoveTo(
-                    SetVariable
-                    .create('amazing_set_variable_widget_two')
-                    .variable('myVarTwo', '{{ payload.act.like.this.should.be.this }}')
-                )
-            )
-        
-        flow = Flow.create('amazing_flow').start(amazingSetVariableWidgetOne).end();
-    })
-    
-    it('should miss myVarTwo if data.payload.act.like.that is in array', () => {
-        const payload = flow({
-            act: {
-                like: { 
-                    that: 'that', 
-                    this: { 
-                        should: { 
-                            be: { 
-                                this:'this' 
-                            } 
-                        } 
-                    }, 
-                    those: 'those' 
-                }
-            }
-        });
+describe("Receives Split widget's", () => {
+  let flow: (a: any) => any;
 
-        expect(payload).resolves.toMatchObject({
-            variables: { 
-                myVarOne: 'that',
-                myVarThree: 'those'
-            }
-        });
-        expect(payload).resolves.not.toMatchObject({
-            variables: { 
-                myVarTwo: 'this',
-            }
-        });
+  beforeAll(() => {
+    amazingSetVariableWidgetOne.moveTo(
+      Split.create("amazing_split_widget")
+        .case((data: any) =>
+          Compare.is(data.payload.act.like.that).in(["this", "those", "that"]),
+        )
+        .moveTo(
+          SetVariable.create("amazing_set_variable_widget_three").variable(
+            "myVarThree",
+            "{{ payload.act.like.those }}",
+          ),
+        )
+        .elseMoveTo(
+          SetVariable.create("amazing_set_variable_widget_two").variable(
+            "myVarTwo",
+            "{{ payload.act.like.this.should.be.this }}",
+          ),
+        ),
+    );
+
+    flow = Flow.create("amazing_flow").start(amazingSetVariableWidgetOne).end();
+  });
+
+  it("should miss myVarTwo if data.payload.act.like.that is in array", () => {
+    const payload = flow({
+      act: {
+        like: {
+          that: "that",
+          this: {
+            should: {
+              be: {
+                this: "this",
+              },
+            },
+          },
+          those: "those",
+        },
+      },
     });
 
-    it('should not miss myVarTwo if data.payload.act.like.that is not in array', () => {
-        const payload = flow({
-            act: {
-                like: { 
-                    that: 'they', 
-                    this: { 
-                        should: { 
-                            be: { 
-                                this:'this' 
-                            } 
-                        } 
-                    }, 
-                    those: 'those' 
-                }
-            }
-        });
-
-        expect(payload).resolves.toMatchObject({
-            variables: { 
-                myVarOne: 'they',
-                myVarTwo: 'this',
-            }
-        });
-        expect(payload).resolves.not.toMatchObject({
-            variables: { 
-                myVarThree: 'those'
-            }
-        });
+    expect(payload).resolves.toMatchObject({
+      variables: {
+        myVarOne: "that",
+        myVarThree: "those",
+      },
     });
+    expect(payload).resolves.not.toMatchObject({
+      variables: {
+        myVarTwo: "this",
+      },
+    });
+  });
+
+  it("should not miss myVarTwo if data.payload.act.like.that is not in array", () => {
+    const payload = flow({
+      act: {
+        like: {
+          that: "they",
+          this: {
+            should: {
+              be: {
+                this: "this",
+              },
+            },
+          },
+          those: "those",
+        },
+      },
+    });
+
+    expect(payload).resolves.toMatchObject({
+      variables: {
+        myVarOne: "they",
+        myVarTwo: "this",
+      },
+    });
+    expect(payload).resolves.not.toMatchObject({
+      variables: {
+        myVarThree: "those",
+      },
+    });
+  });
 });

--- a/test/widget-core.test.ts
+++ b/test/widget-core.test.ts
@@ -1,0 +1,51 @@
+import { CustomWidget, Flow, SetVariable } from "../src";
+
+class SlowAppend extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    data.payload.log = data.payload.log || [];
+    data.payload.log.push("done");
+  }
+}
+
+class Boom extends CustomWidget {
+  protected async run(): Promise<void> {
+    throw new Error("boom");
+  }
+}
+
+class Recover extends CustomWidget {
+  protected async run(data: any): Promise<void> {
+    data.payload.recovered = true;
+  }
+}
+
+describe("Widget core execution", () => {
+  it("awaits the full downstream chain after SetVariable", async () => {
+    const extract = SetVariable.create("extract")
+      .variable("seed", "{{ payload.seed }}")
+      .moveTo(SlowAppend.create("slow"));
+
+    const flow = Flow.create("await_chain").start(extract).end();
+
+    const result = await flow({ seed: 1 });
+
+    expect(result.variables.seed).toBe(1);
+    expect(result.payload.log).toEqual(["done"]);
+  });
+
+  it("propagates unhandled errors instead of swallowing them", async () => {
+    const flow = Flow.create("propagates").start(Boom.create("boom")).end();
+
+    await expect(flow({})).rejects.toThrow("boom");
+  });
+
+  it("routes a thrown error to the failure path when one exists", async () => {
+    const boom = Boom.create("boom").elseMoveTo(Recover.create("recover"));
+    const flow = Flow.create("recovers").start(boom).end();
+
+    const result = await flow({});
+
+    expect(result.payload.recovered).toBe(true);
+  });
+});


### PR DESCRIPTION
- ⚡ Add Parallel widget: run named branches concurrently on isolated clones, then merge;
- 🧺 Add ParallelMap: bounded-concurrency batch map with partial-failure collection;
- 🔁 Add Retry (fixed/exponential backoff + jitter) and CircuitBreaker decorator widgets;
- 🛠️ Harden engine with a run() lifecycle hook and a fully awaited execution chain;
- 🚨 Propagate unhandled errors instead of swallowing them; add typed RouteSignal;
- 🔧 SetVariable now accumulates multiple variable() calls; fix Comparator.notEqual;
- 📚 Add resilient ETL example, repair examples 01/03/04, refresh README and CLAUDE.md;
- ✅ Cover new widgets and fixes with Jest suites (29 passing).

Closes the first two roadmap items. Note: unhandled errors now propagate (behavior change).